### PR TITLE
hotfix:  fixed macOS issues with alt+digit hotkeys[WTEL-4516]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-workspaces",
-  "version": "24.02.1",
+  "version": "24.04.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-workspaces",
-      "version": "24.02.1",
+      "version": "24.04.0",
       "dependencies": {
         "@tinymce/tinymce-vue": "^5.1.1",
         "@vue/compat": "^3.4.15",

--- a/src/ui/hotkeys/digitCodes.js
+++ b/src/ui/hotkeys/digitCodes.js
@@ -1,0 +1,14 @@
+const digitCodes = 
+[
+  'Digit1',
+  'Digit2',
+  'Digit3',
+  'Digit4',
+  'Digit5',
+  'Digit6',
+  'Digit7',
+  'Digit8',
+  'Digit9',
+];
+
+export default digitCodes;

--- a/src/ui/hotkeys/digitKeys.js
+++ b/src/ui/hotkeys/digitKeys.js
@@ -1,3 +1,0 @@
-const digitKeys = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
-
-export default digitKeys;

--- a/src/ui/hotkeys/useHotkeys.js
+++ b/src/ui/hotkeys/useHotkeys.js
@@ -1,5 +1,5 @@
 import HotkeyAction from "./HotkeysActiom.enum";
-import digitKeys from "./digitKeys";
+import digitCodes from "./digitCodes";
 
 /*
 NOTE:
@@ -16,8 +16,8 @@ const globalSub = Object.values(HotkeyAction).reduce((acc, event) => {
 const globalListener = (event) => {
   // TOGGLE_NEW_CALL
   if (event.altKey && event.code === 'KeyN') {
-    event.preventDefault();
     globalSub[HotkeyAction.NEW_CALL].forEach((callback) => {
+      event.preventDefault();
       callback(event);
     });
   }
@@ -63,7 +63,7 @@ const globalListener = (event) => {
   }
 
   // FORM SUBMITION
-  else if (event.altKey && digitKeys.includes(event.key)) {
+  else if (event.altKey && digitCodes.includes(event.code)) {
     globalSub[HotkeyAction.SUBMIT_FORM].forEach((callback) => {
       event.preventDefault();
       callback(event);

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/the-processing-form.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/the-processing-form.vue
@@ -114,7 +114,9 @@ export default {
         {
           event: HotkeyAction.SUBMIT_FORM,
           callback: (event) => {
-            const index = +event.key - 1;
+            // get digit form event.code. e.g "1" form "Digit1" string
+            const digit = event.code[event.code.length - 1];
+            const index = +digit - 1;
             const button = this.$refs['form-action-buttons'][index].$el;
             if (button) button.focus();
           },


### PR DESCRIPTION
It was an issue with "option(alt)+someDigit" combination on macOS.
It turned out that these combinations create special characters. That is, event.key could have the value of @. Therefore, what worked on Windows did not work on macOS. 