### PR TITLE
hotfix: send task in emit instead of the element we click on [WTEL-7494] 

### DIFF
--- a/src/ui/modules/queue-section/modules/call-queue/components/manual-queue/manual-queue-preview.vue
+++ b/src/ui/modules/queue-section/modules/call-queue/components/manual-queue/manual-queue-preview.vue
@@ -128,11 +128,11 @@ const wait = computed(() => {
   return `${minutes}:${seconds}`;
 });
 
-function accept(task) {
+function accept() {
   if (showLoader.value) return;
 
   showLoader.value = true;
-  emit('accept', task);
+  emit('accept', props.task);
   showLoader.value = false;
 }
 </script>


### PR DESCRIPTION
task: https://webitel.atlassian.net/browse/WTEL-7494
to do: send task in emit instead of the element we click on. In action try get attemptId