### PR TITLE
fix: add date of first communication in chat [WTEL-9418]

### DIFF
--- a/src/ui/modules/work-section/modules/chat/chat-messaging/current-chat/current-chat.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/current-chat/current-chat.vue
@@ -17,7 +17,7 @@
       >
         <template #before-message>
           <chat-date
-            v-if="showChatDate(index)"
+            v-if="showChatDate(index) || index === 0"
             :date="message.createdAt"
           />
         </template>


### PR DESCRIPTION
Проблема полягала в тому, що якщо хтось написав у чат, але цієї людини немає в контактах, то з самого верху чату не відображалася дата першої комунікації. Якщо спілкування в чаті триває більше доби, то наступні дати відображаються коректно.