### PR TITLE
fix: add useMediaScroll composable to currant-chat.vue for scrolling images [WTEL-8208]

### DIFF
--- a/src/ui/modules/work-section/modules/chat/chat-messaging/current-chat/current-chat.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/current-chat/current-chat.vue
@@ -53,6 +53,7 @@ import ChatActivityInfo from '../components/chat-activity-info.vue';
 import ChatDate from '../components/chat-date.vue';
 import ScrollToBottomBtn from '../components/scroll-to-bottom-btn.vue';
 import { useChatScroll } from '../composables/useChatScroll.js';
+import { useMediaScroll } from '@webitel/ui-chats/ui';
 import Message from '../message/chat-message.vue';
 import { useChatMessages } from '../message/composables/useChatMessages.js';
 
@@ -89,9 +90,12 @@ const {
 	updateThreshold,
 } = useChatScroll(el);
 
-onUnmounted(() => {
-	cleanChatPlayers();
-});
+const { startObserving } = useMediaScroll(
+  el,
+  () => {
+     scrollToBottom('smooth', 'useMediaScroll')
+  },
+);
 
 const openMedia = (message) =>
 	store.dispatch(`${chatMediaNamespace}/OPEN_MEDIA`, message);
@@ -109,6 +113,10 @@ watch(
 		immediate: true,
 	},
 );
+
+onMounted(() => {
+  startObserving();
+});
 
 onUnmounted(() => {
 	cleanChatPlayers();

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/current-chat/current-chat.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/current-chat/current-chat.vue
@@ -38,6 +38,7 @@
 </template>
 
 <script setup>
+import { useMediaScroll } from '@webitel/ui-chats/ui';
 import { ComponentSize } from '@webitel/ui-sdk/src/enums/index.js';
 import {
 	computed,
@@ -48,12 +49,10 @@ import {
 	watch,
 } from 'vue';
 import { useStore } from 'vuex';
-
 import ChatActivityInfo from '../components/chat-activity-info.vue';
 import ChatDate from '../components/chat-date.vue';
 import ScrollToBottomBtn from '../components/scroll-to-bottom-btn.vue';
 import { useChatScroll } from '../composables/useChatScroll.js';
-import { useMediaScroll } from '@webitel/ui-chats/ui';
 import Message from '../message/chat-message.vue';
 import { useChatMessages } from '../message/composables/useChatMessages.js';
 
@@ -90,12 +89,9 @@ const {
 	updateThreshold,
 } = useChatScroll(el);
 
-const { startObserving } = useMediaScroll(
-  el,
-  () => {
-     scrollToBottom('smooth', 'useMediaScroll')
-  },
-);
+const { startObserving } = useMediaScroll(el, () => {
+	scrollToBottom('smooth', 'useMediaScroll');
+});
 
 const openMedia = (message) =>
 	store.dispatch(`${chatMediaNamespace}/OPEN_MEDIA`, message);
@@ -115,7 +111,7 @@ watch(
 );
 
 onMounted(() => {
-  startObserving();
+	startObserving();
 });
 
 onUnmounted(() => {

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/current-chat/current-chat.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/current-chat/current-chat.vue
@@ -90,7 +90,7 @@ const {
 } = useChatScroll(el);
 
 const { startObserving } = useMediaScroll(el, () => {
-	scrollToBottom('smooth', 'useMediaScroll');
+	scrollToBottom('smooth');
 });
 
 const openMedia = (message) =>


### PR DESCRIPTION
Проблема:
При завантаженні зображення в чаті скрол не опускався до кінця. useChatScroll реагував на зміну messages.length і викликав scrollToBottom в момент коли картинка ще не завантажилась і мала висоту 0. Після завантаження картинки висота контейнера збільшувалась, але скрол вже відпрацював.
Рішення:
useMediaScroll експортовано з бібліотеки через src/ui/index.ts і підключено в current-chat.vue. Окремий локальний файл composable в проекті не створювався — використовується той самий composable з бібліотеки щоб уникнути дублювання логіки.

Додатково видалено дублювання
onUnmounted(() => {
	cleanChatPlayers();
});