### PR TITLE
fix: add condition by user name in showAvatar method in useChatMessages.js composable [WTEL-9566]

### DIFF
--- a/src/ui/modules/work-section/modules/chat/chat-messaging/message/composables/useChatMessages.js
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/message/composables/useChatMessages.js
@@ -47,6 +47,7 @@ export const useChatMessages = () => {
 		return (
 			index === 0 ||
 			message.member?.type !== prevMessage.member?.type ||
+			message.member?.name !== prevMessage.member?.name ||
 			isBot(message) !== isBot(prevMessage)
 		);
 	};


### PR DESCRIPTION
Проблема: у методі showAvatar в useChatMessages.js composable однією з умов було виведення аватарки при різних типах мембера, але при трансфері на іншого оператора тип мембера не змінюється, змінюється лише ім'я.

Рішення: додала додаткову умову порівняння  імені мембера, при цьому порівняння  типу залишила на випадок однакових імен при різних типах.