### PR TITLE
hotfix: remove chatContactIsLoaded from contact watcher in the-chat.vue [WTEL-9646]

### DIFF
--- a/src/ui/modules/work-section/modules/chat/the-chat.vue
+++ b/src/ui/modules/work-section/modules/chat/the-chat.vue
@@ -103,9 +103,7 @@ export default {
 		contact: {
 			// TODO: need to be removed after chat backend refactoring https://webitel.atlassian.net/browse/WTEL-6271
 			async handler() {
-				this.chatContactIsLoaded = false;
 				this.chatContact = await getLinkedContact(this.chat, this.contact); // instead of this we must use this.chat.contact. This logic must be removed, when back-end will be able to return chat.contact: { id: fieldValue, name: fieldValue } (when contact was linked to chat)
-				this.chatContactIsLoaded = true;
 			},
 		},
 	},

--- a/src/ui/modules/work-section/modules/chat/the-chat.vue
+++ b/src/ui/modules/work-section/modules/chat/the-chat.vue
@@ -102,8 +102,12 @@ export default {
 		},
 		contact: {
 			// TODO: need to be removed after chat backend refactoring https://webitel.atlassian.net/browse/WTEL-6271
-			async handler() {
+			async handler(newContact) {
+				if (newContact?.id === this.chatContact?.id) return;
+
+				this.chatContactIsLoaded = false;
 				this.chatContact = await getLinkedContact(this.chat, this.contact); // instead of this we must use this.chat.contact. This logic must be removed, when back-end will be able to return chat.contact: { id: fieldValue, name: fieldValue } (when contact was linked to chat)
+				this.chatContactIsLoaded = true;
 			},
 		},
 	},


### PR DESCRIPTION
**Проблема**
При першому переході на вкладку client-info відбувалось перемонтування _chat-messaging_ та _the-chat-history_. Це спричиняв вотчер contact у _the-chat.vue_ - він встановлював chatContactIsLoaded = false, що призводило до розмонтування task-container разом із усіма дочірніми компонентами, після чого вони одразу монтувались знову.
Корінна причина: _client-info_ при першому монтуванні викликає INITIALIZE_CONTACT - LOAD_CHAT_CONTACT - SET_CONTACT, через що state.contact змінювався з null на об'єкт контакту. Вотчер це бачив і запускав повний цикл перемонтування — хоча чат на цей момент вже був відкритий і історія завантажена.

**Вирішення**
Прибрано chatContactIsLoaded = false / true з вотчера contact. Чат вже відображений, тому достатньо просто оновити chatContact без перемонтування.
chatContactIsLoaded залишається у вотчері chatId - там він потрібен, бо чат реально змінився і потрібно дочекатись контакту перед рендером.


**UPD**: флаг потрібен для сценарію коли агент реально змінює контакт під час активного чату, щоб показати користувачу що чат оновився.
Тому замість того щоб прибирати флаги, додала перевірку по id: якщо контакт що прийшов у стор має той самий id що вже є в chatContact - це просто перша ініціалізація з правої панелі, перемонтовувати нічого не треба. Якщо id відрізняється - контакт реально змінився, показуємо лоадер і оновлюємо.
