### PR TITLE
feat: add flag to reset loader in contact.js [WTEL-9714]

### DIFF
--- a/src/ui/modules/info-section/modules/client-info/modules/contact/store/contact.js
+++ b/src/ui/modules/info-section/modules/client-info/modules/contact/store/contact.js
@@ -55,17 +55,27 @@ const actions = {
 			qin,
 			size: 100,
 		}; // load only 100 (should be enough) // https://webitel.atlassian.net/browse/WTEL-7906
+		let linkedContact = false;
 		try {
 			context.commit('SET_IS_LOADING', true);
 			const { items: contacts } = await ContactsAPI.getList(searchParams);
 
 			if (contacts.length === 1) {
-				return context.dispatch('LINK_CONTACT', contacts[0]);
+				//@author PolinaSukhorukova-webitel
+				//isLoading is intentionally not reset here —
+				//responsibility is passed to LOAD_CONTACT, which is triggered
+				//by the watcher in the-contact.vue after contactId updated.
+				//LOAD_CONTACT will reset isLoading in its own finally block.
+				linkedContact = true;
+				context.dispatch('LINK_CONTACT', contacts[0]);
+				return;
 			}
 
 			context.commit('SET_CONTACTS_BY_DESTINATION', contacts);
 		} finally {
-			context.commit('SET_IS_LOADING', false);
+			if (!linkedContact) {
+				context.commit('SET_IS_LOADING', false);
+			}
 		}
 	},
 	SEARCH_CONTACTS: async (context, searchParams) => {


### PR DESCRIPTION
**Проблема:** При маунті компонента контакту виникав візуальний стрибок: спочатку рендерився лоадер, потім empty-contact, знов лоадер, і лише після цього — картка контакту. Це відбувалося через те, що LOAD_CONTACTS_BY_DESTINATION скидав isLoading: false у finally одразу після LINK_CONTACT, тоді як реальна поява контакту в сторі відбувається пізніше — через watcher у компоненті, який запускає LOAD_CONTACT, який в свою чергу теж маніпулює з isLoading .

**Рішення:** Якщо знайдено один контакт і ми йдемо в LINK_CONTACT, isLoading навмисно не скидається в finally — відповідальність за скидання лоадера передається LOAD_CONTACT, який має власний try/finally і викликається через watcher після того як контакт з'явиться в таску.