### PR TITLE
fix: remove wt-notification-bar from the-agent-workspace.vue and error-page.vue [WTEL-9771]

### DIFF
--- a/src/ui/components/error-page.vue
+++ b/src/ui/components/error-page.vue
@@ -1,6 +1,5 @@
 <template>
   <main class="main-error-page">
-    <wt-notifications-bar />
     <app-header />
     <wt-error-page :type="errorType" @back="handleBack" />
   </main>

--- a/src/ui/components/the-agent-workspace.vue
+++ b/src/ui/components/the-agent-workspace.vue
@@ -14,7 +14,6 @@
     <desc-track-auth-error-popup v-if="isDescTrackAuthErrorPopup" />
     <desc-track-auth-success-popup v-model:shown="isDescTrackAuthSuccessPopup" />
 
-    <wt-notifications-bar />
     <cc-header />
     <div class="workspace-wrap">
       <widget-bar />


### PR DESCRIPTION
** Проблема
під час виконання задачі була виявлена небажана поведінка нотифікацій, а саме нашаровування нотифікацій одні на одні. Дослідили и виявила, що така поведінка відбувається через множине підключення компоненту нотифікацій по проєкту.

** Рішення 
видалила компонент з the-agent-workspace та error-page, залишила тільки в the-app