### PR TITLE
fix: remove session init to watcher in missed-queue-container.vue and offline-queue-container.vue, prevent init session without permissions in the-agent-workspace.vue [WTEL-9282]

### DIFF
--- a/src/features/modules/member/member.js
+++ b/src/features/modules/member/member.js
@@ -1,3 +1,4 @@
+import { useCachedInterval } from '@webitel/ui-sdk/src/composables/useCachedInterval/useCachedInterval';
 import WorkspaceStates from '../../../ui/enums/WorkspaceState.enum';
 
 const state = {
@@ -72,6 +73,16 @@ const actions = {
 				root: true,
 			},
 		);
+	},
+
+	SUBSRIBE_MEMBER_LIST: (context) => {
+		const { subscribe } = useCachedInterval({
+			timeout: 15 * 1000,
+		});
+
+		subscribe(async () => {
+			const response = await context.dispatch('LOAD_DATA_LIST');
+		});
 	},
 };
 

--- a/src/ui/components/the-agent-workspace.vue
+++ b/src/ui/components/the-agent-workspace.vue
@@ -8,7 +8,7 @@
     <welcome-popup
       v-if="isWelcomePopup"
       :loading="isInitLoading"
-      @input="initSession"
+      @input="handleWelcomeClose"
     ></welcome-popup>
 
     <desc-track-auth-error-popup v-if="isDescTrackAuthErrorPopup" />
@@ -109,6 +109,14 @@ const openSession = () => store.dispatch('workspace/OPEN_SESSION');
 const closeSession = () => store.dispatch('workspace/CLOSE_SESSION');
 const agentLogout = () => store.dispatch('features/status/AGENT_LOGOUT');
 
+const handleWelcomeClose = async (allGranted: boolean) => {
+	isWelcomePopup.value = false;
+
+	if (allGranted) {
+		await initSession();
+	}
+};
+
 const initSession = async () => {
 	try {
 		isInitLoading.value = true;
@@ -137,7 +145,6 @@ const initSession = async () => {
 		}
 	} finally {
 		isInitLoading.value = false;
-		isWelcomePopup.value = false;
 	}
 };
 

--- a/src/ui/modules/popups/welcome-popup/welcome-popup.vue
+++ b/src/ui/modules/popups/welcome-popup/welcome-popup.vue
@@ -103,7 +103,9 @@ export default {
 		close() {
 			if (!this.loading) {
 				this.playSilence();
-				this.$emit('input');
+				const allGranted =
+					this.mic.status && this.notification.status && this.camera.status;
+				this.$emit('input', allGranted);
 			}
 		},
 		async checkMic() {

--- a/src/ui/modules/popups/welcome-popup/welcome-popup.vue
+++ b/src/ui/modules/popups/welcome-popup/welcome-popup.vue
@@ -103,9 +103,9 @@ export default {
 		close() {
 			if (!this.loading) {
 				this.playSilence();
-				const allGranted =
+				const grantStatus =
 					this.mic.status && this.notification.status && this.camera.status;
-				this.$emit('input', allGranted);
+				this.$emit('input', grantStatus);
 			}
 		},
 		async checkMic() {

--- a/src/ui/modules/queue-section/modules/call-queue/components/missed-queue/__tests__/missed-queue-container.spec.js
+++ b/src/ui/modules/queue-section/modules/call-queue/components/missed-queue/__tests__/missed-queue-container.spec.js
@@ -1,12 +1,7 @@
 import { mount, shallowMount } from '@vue/test-utils';
-import { WebSocketConnectionState } from '../../../../../../../../ui/enums/WebSocketConnectionState.enum';
 import MissedQueueContainer from '../missed-queue-container.vue';
 
 describe('MissedQueueContainer', () => {
-	const initializeMissedMock = vi
-		.spyOn(MissedQueueContainer.methods, 'initializeMissed')
-		.mockImplementation(() => {});
-
 	it('renders missed queue container root', () => {
 		const wrapper = shallowMount(MissedQueueContainer, {
 			computed: {
@@ -25,25 +20,6 @@ describe('MissedQueueContainer', () => {
 				})
 				.exists(),
 		).toBe(true);
-	});
-	it('calls initializeMissed when websocket becomes connected', () => {
-		initializeMissedMock.mockClear();
-
-		const wrapper = shallowMount(MissedQueueContainer, {
-			computed: {
-				missedList: () => [
-					{
-						id: 'jest',
-					},
-				],
-			},
-		});
-
-		const watcher = MissedQueueContainer.watch.wsConnectionState.handler;
-
-		watcher.call(wrapper.vm, WebSocketConnectionState.Connected);
-
-		expect(initializeMissedMock).toHaveBeenCalled();
 	});
 
 	it('calls redial on call preview event', () => {

--- a/src/ui/modules/queue-section/modules/call-queue/components/missed-queue/__tests__/missed-queue-container.spec.js
+++ b/src/ui/modules/queue-section/modules/call-queue/components/missed-queue/__tests__/missed-queue-container.spec.js
@@ -1,5 +1,5 @@
 import { mount, shallowMount } from '@vue/test-utils';
-
+import { WebSocketConnectionState } from '../../../../../../../../ui/enums/WebSocketConnectionState.enum';
 import MissedQueueContainer from '../missed-queue-container.vue';
 
 describe('MissedQueueContainer', () => {
@@ -26,9 +26,10 @@ describe('MissedQueueContainer', () => {
 				.exists(),
 		).toBe(true);
 	});
-	it('calls initializeMissed on created hook', () => {
+	it('calls initializeMissed when websocket becomes connected', () => {
 		initializeMissedMock.mockClear();
-		shallowMount(MissedQueueContainer, {
+
+		const wrapper = shallowMount(MissedQueueContainer, {
 			computed: {
 				missedList: () => [
 					{
@@ -37,6 +38,11 @@ describe('MissedQueueContainer', () => {
 				],
 			},
 		});
+
+		const watcher = MissedQueueContainer.watch.wsConnectionState.handler;
+
+		watcher.call(wrapper.vm, WebSocketConnectionState.Connected);
+
 		expect(initializeMissedMock).toHaveBeenCalled();
 	});
 

--- a/src/ui/modules/queue-section/modules/call-queue/components/missed-queue/missed-queue-container.vue
+++ b/src/ui/modules/queue-section/modules/call-queue/components/missed-queue/missed-queue-container.vue
@@ -18,12 +18,17 @@
 </template>
 
 <script>
-import { mapActions, mapState } from 'vuex';
+import { watch } from 'vue';
+import { mapActions, mapState, useStore } from 'vuex';
 
+import { useWebSocketClient } from '../../../../../../../app/api/agent-workspace/websocket/useWebSocketClient';
 import sizeMixin from '../../../../../../../app/mixins/sizeMixin';
+import { WebSocketConnectionState } from '../../../../../../../ui/enums/WebSocketConnectionState.enum';
 import LoadMoreButton from '../../../../../../_shared/components/load-more-button.vue';
 import TaskQueueContainer from '../../../_shared/components/task-queue-container.vue';
 import MissedPreview from './missed-queue-preview.vue';
+
+const { state } = useWebSocketClient();
 
 export default {
 	name: 'MissedQueueContainer',
@@ -41,6 +46,9 @@ export default {
 			missedList: (state) => state.missedList,
 			next: (state) => state.next,
 		}),
+		wsConnectionState() {
+			return state.value;
+		},
 	},
 
 	methods: {
@@ -52,8 +60,15 @@ export default {
 		}),
 	},
 
-	created() {
-		this.initializeMissed();
+	watch: {
+		wsConnectionState: {
+			handler(s) {
+				if (s === WebSocketConnectionState.Connected) {
+					this.initializeMissed();
+				}
+			},
+			once: true,
+		},
 	},
 };
 </script>

--- a/src/ui/modules/queue-section/modules/call-queue/components/missed-queue/missed-queue-container.vue
+++ b/src/ui/modules/queue-section/modules/call-queue/components/missed-queue/missed-queue-container.vue
@@ -18,17 +18,12 @@
 </template>
 
 <script>
-import { watch } from 'vue';
 import { mapActions, mapState, useStore } from 'vuex';
 
-import { useWebSocketClient } from '../../../../../../../app/api/agent-workspace/websocket/useWebSocketClient';
 import sizeMixin from '../../../../../../../app/mixins/sizeMixin';
-import { WebSocketConnectionState } from '../../../../../../../ui/enums/WebSocketConnectionState.enum';
 import LoadMoreButton from '../../../../../../_shared/components/load-more-button.vue';
 import TaskQueueContainer from '../../../_shared/components/task-queue-container.vue';
 import MissedPreview from './missed-queue-preview.vue';
-
-const { state } = useWebSocketClient();
 
 export default {
 	name: 'MissedQueueContainer',
@@ -46,29 +41,14 @@ export default {
 			missedList: (state) => state.missedList,
 			next: (state) => state.next,
 		}),
-		wsConnectionState() {
-			return state.value;
-		},
 	},
 
 	methods: {
 		...mapActions('features/call/missed', {
-			initializeMissed: 'INITIALIZE_MISSED',
 			loadMore: 'LOAD_NEXT_PAGE',
 			redial: 'REDIAL',
 			hideMissed: 'HIDE_MISSED',
 		}),
-	},
-
-	watch: {
-		wsConnectionState: {
-			handler(s) {
-				if (s === WebSocketConnectionState.Connected) {
-					this.initializeMissed();
-				}
-			},
-			once: true,
-		},
 	},
 };
 </script>

--- a/src/ui/modules/queue-section/modules/call-queue/components/offline-queue/offline-queue-container.vue
+++ b/src/ui/modules/queue-section/modules/call-queue/components/offline-queue/offline-queue-container.vue
@@ -4,9 +4,10 @@
   >
     <div ref="scroll-wrap" class="offline-queue-container__scroll-wrap">
       <div
-v-for="(task, index) of dataList"
-           :key="task.id"
-           class="offline-queue-container__items">
+        v-for="(task, index) of dataList"
+        :key="task.id"
+        class="offline-queue-container__items"
+      >
         <offline-preview
           :opened="task === taskOnWorkspace"
           :task="task"
@@ -15,11 +16,6 @@ v-for="(task, index) of dataList"
         />
         <wt-divider v-if="dataList.length > index + 1"/>
       </div>
-      <wt-intersection-observer
-        :canLoadMore="true"
-        :loading="isLoading"
-        @next="handleIntersect"
-      />
     </div>
   </task-queue-container>
 </template>
@@ -27,9 +23,11 @@ v-for="(task, index) of dataList"
 <script setup>
 import WtIntersectionObserver from '@webitel/ui-sdk/components/wt-intersection-observer/wt-intersection-observer.vue';
 import { useCachedInterval } from '@webitel/ui-sdk/src/composables/useCachedInterval/useCachedInterval';
-import { computed, onMounted, onUnmounted } from 'vue';
+import { computed, onUnmounted, watch } from 'vue';
 import { useStore } from 'vuex';
+import { useWebSocketClient } from '../../../../../../../app/api/agent-workspace/websocket/useWebSocketClient';
 import useInfiniteScroll from '../../../../../../../app/composables/useInfiniteScroll';
+import { WebSocketConnectionState } from '../../../../../../../ui/enums/WebSocketConnectionState.enum';
 import TaskQueueContainer from '../../../_shared/components/task-queue-container.vue';
 import OfflinePreview from './offline-queue-preview.vue';
 
@@ -44,37 +42,23 @@ const store = useStore();
 const { subscribe } = useCachedInterval({
 	timeout: 15 * 1000,
 });
+const { state } = useWebSocketClient();
 
 const dataList = computed(() => store.state.features.member?.memberList || []);
 const taskOnWorkspace = computed(
 	() => store.getters['workspace/TASK_ON_WORKSPACE'],
 );
+const isConnected = computed(
+	() => state.value === WebSocketConnectionState.Connected,
+);
 
-const fetchFn = async (params) => {
-	const response = await store.dispatch(
-		'features/member/LOAD_DATA_LIST',
-		params,
-	);
+const loadDataList = async () => {
+	const response = await store.dispatch('features/member/LOAD_DATA_LIST');
 	return {
 		items: response.items,
 		next: response.next,
 	};
 };
-
-const { isLoading, dataSearch, handleIntersect, resetData } = useInfiniteScroll(
-	{
-		fetchFn,
-		size: 20,
-	},
-);
-
-// Use the same function for initial load and infinite scroll
-const loadDataList = () =>
-	fetchFn({
-		search: dataSearch.value,
-		page: 1,
-		size: 20,
-	});
 
 const toggleMemberDisplay = (task) => {
 	taskOnWorkspace.value.id === task.id
@@ -82,9 +66,17 @@ const toggleMemberDisplay = (task) => {
 		: store.dispatch('features/member/OPEN_MEMBER_ON_WORKSPACE', task);
 };
 
-onMounted(() => {
-	subscribe(loadDataList);
-});
+watch(
+	isConnected,
+	(connected) => {
+		if (connected) {
+			subscribe(loadDataList);
+		}
+	},
+	{
+		once: true,
+	},
+);
 
 onUnmounted(() => {
 	/*

--- a/src/ui/modules/queue-section/modules/call-queue/components/offline-queue/offline-queue-container.vue
+++ b/src/ui/modules/queue-section/modules/call-queue/components/offline-queue/offline-queue-container.vue
@@ -21,13 +21,8 @@
 </template>
 
 <script setup>
-import WtIntersectionObserver from '@webitel/ui-sdk/components/wt-intersection-observer/wt-intersection-observer.vue';
-import { useCachedInterval } from '@webitel/ui-sdk/src/composables/useCachedInterval/useCachedInterval';
-import { computed, onUnmounted, watch } from 'vue';
+import { computed, onUnmounted } from 'vue';
 import { useStore } from 'vuex';
-import { useWebSocketClient } from '../../../../../../../app/api/agent-workspace/websocket/useWebSocketClient';
-import useInfiniteScroll from '../../../../../../../app/composables/useInfiniteScroll';
-import { WebSocketConnectionState } from '../../../../../../../ui/enums/WebSocketConnectionState.enum';
 import TaskQueueContainer from '../../../_shared/components/task-queue-container.vue';
 import OfflinePreview from './offline-queue-preview.vue';
 
@@ -39,44 +34,17 @@ const props = defineProps({
 });
 
 const store = useStore();
-const { subscribe } = useCachedInterval({
-	timeout: 15 * 1000,
-});
-const { state } = useWebSocketClient();
 
 const dataList = computed(() => store.state.features.member?.memberList || []);
 const taskOnWorkspace = computed(
 	() => store.getters['workspace/TASK_ON_WORKSPACE'],
 );
-const isConnected = computed(
-	() => state.value === WebSocketConnectionState.Connected,
-);
-
-const loadDataList = async () => {
-	const response = await store.dispatch('features/member/LOAD_DATA_LIST');
-	return {
-		items: response.items,
-		next: response.next,
-	};
-};
 
 const toggleMemberDisplay = (task) => {
 	taskOnWorkspace.value.id === task.id
 		? store.dispatch('features/member/RESET_WORKSPACE')
 		: store.dispatch('features/member/OPEN_MEMBER_ON_WORKSPACE', task);
 };
-
-watch(
-	isConnected,
-	(connected) => {
-		if (connected) {
-			subscribe(loadDataList);
-		}
-	},
-	{
-		once: true,
-	},
-);
 
 onUnmounted(() => {
 	/*

--- a/src/ui/store/__tests__/agent-workspace.spec.js
+++ b/src/ui/store/__tests__/agent-workspace.spec.js
@@ -95,10 +95,10 @@ describe('workspace store: actions', () => {
 		);
 	});
 
-	it('OPEN_SESSION dispatches call/missed/LOAD_DATA_LIST (loads missed calls list)', async () => {
+	it('OPEN_SESSION dispatches call/missed/INITIALIZE_MISSED (init loads missed calls list)', async () => {
 		await workspaceModule.actions.OPEN_SESSION(context);
 		expect(context.dispatch).toHaveBeenCalledWith(
-			'features/call/missed/LOAD_DATA_LIST',
+			'features/call/missed/INITIALIZE_MISSED',
 			null,
 			{
 				root: true,
@@ -106,10 +106,10 @@ describe('workspace store: actions', () => {
 		);
 	});
 
-	it('OPEN_SESSION dispatches member/LOAD_DATA_LIST (loads offline queue members)', async () => {
+	it('OPEN_SESSION dispatches member/SUBSRIBE_MEMBER_LIST (subscribes to loading offline queue members)', async () => {
 		await workspaceModule.actions.OPEN_SESSION(context);
 		expect(context.dispatch).toHaveBeenCalledWith(
-			'features/member/LOAD_DATA_LIST',
+			'features/member/SUBSRIBE_MEMBER_LIST',
 			null,
 			{
 				root: true,

--- a/src/ui/store/agent-workspace.js
+++ b/src/ui/store/agent-workspace.js
@@ -52,7 +52,7 @@ const actions = {
 			context.dispatch('features/job/SUBSCRIBE_JOBS', null, {
 				root: true,
 			}),
-			context.dispatch('features/call/missed/LOAD_DATA_LIST', null, {
+			context.dispatch('features/call/missed/INITIALIZE_MISSED', null, {
 				root: true,
 			}),
 			context.dispatch('features/call/manual/INITIALIZE_MANUAL_LIST', null, {
@@ -61,7 +61,7 @@ const actions = {
 			context.dispatch('features/chat/manual/INITIALIZE_MANUAL_LIST', null, {
 				root: true,
 			}),
-			context.dispatch('features/member/LOAD_DATA_LIST', null, {
+			context.dispatch('features/member/SUBSRIBE_MEMBER_LIST', null, {
 				root: true,
 			}),
 		]);


### PR DESCRIPTION
## Проблема
вирішення задачі полягало в вирішенні двух проблем:
1. відбувалась ініціалізація сесії без врахування надання дозволів, просто натиснули ок, навіть якщо дозволів нема - ініціалізація відбулась
2. в двох компонентах відбувалась ініціалізація сесії ще навіть ДО закритяя модальног вікна в хуках created/mounted

## Вирішення
1. При закритті модалки додала перевірку надання дозволів, якщо не всі дозволи надані - ініціалізація сесії не відбувається.
2. В компонентах, в яких відбувалася ініціалізація при створенні, перенесла створення сесії в спостерігач, який спрацьовує, коли відбулось підключення, і вже після цього бере необхідні дані з сокету.