### PR TITLE
feat: add cooldown timer to useLoader.ts composable [WTEL-6752]

### DIFF
--- a/src/ui/composables/useLoader.ts
+++ b/src/ui/composables/useLoader.ts
@@ -1,8 +1,11 @@
-import { ref } from 'vue';
+import { onScopeDispose, ref } from 'vue';
+
+const COOLDOWN_MS = 1000;
 
 export function useLoader() {
 	/** Tracks loading state per list item by ID. */
 	const loadingId = ref<string | null>(null);
+	let cooldownTimer: ReturnType<typeof setTimeout> | null = null;
 
 	function showLoader(id: string) {
 		return loadingId.value === id;
@@ -14,9 +17,23 @@ export function useLoader() {
 		try {
 			await callback();
 		} finally {
-			loadingId.value = null;
+			/**
+			 * @author PolinaSukhorukova-webitel
+			 *
+			 * [WTEL-6752](https://webitel.atlassian.net/browse/WTEL-6752?focusedCommentId=765237)
+			 * makeCall resolves as soon as the server registers the call,
+			 * so reset the flag after a cooldown to debounce rapid double-clicks.
+			 */
+			cooldownTimer = setTimeout(() => {
+				loadingId.value = null;
+				cooldownTimer = null;
+			}, COOLDOWN_MS);
 		}
 	}
+
+	onScopeDispose(() => {
+		if (cooldownTimer) clearTimeout(cooldownTimer);
+	});
 
 	return {
 		loadingId,


### PR DESCRIPTION
## Проблема
Наведено як приклад поведінки, не обмежується лише колбеком makeCall.
При швидких повторних кліках по кнопках дзвінка відправлялися два дзвінки. runWithLoader скидав loadingId одразу після makeCall (або схожі), але makeCall резолвиться щойно сервер реєструє дзвінок - майже миттєво, а сам дзвінок ще не встигає потрапити в сокет - є невелике вікно між подіями. Через це перший дзвінок встигав завершитися раніше за повторний клік, прапорець скидався до null, і другий клік проходив перевірку.

##Вирішення: 
Скидання loadingId відкладено на COOLDOWN_MS через setTimeout. Прапорець тримається ще секунду після колбеку та поглинає повторні швидкі кліки. Таймер чиститься через onScopeDispose. Захист лишається на рівні UI: стор CALL штатно підтримує повторні дзвінки (активний іде на hold).