### PR TITLE
chore: fix all vue-tsc typecheck errors and enforce baseline [WTEL-9942]

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,0 +1,25 @@
+import type { Breakpoint } from '@webitel/ui-sdk/plugins/breakpoint/breakpoint.plugin.js';
+
+// The breakpoint plugin injects `$breakpoint` as a Vue global property.
+// Re-declared here so it resolves without relying on the plugin's own
+// declaration file being pulled into the type graph.
+declare module 'vue' {
+	interface ComponentCustomProperties {
+		$breakpoint: Breakpoint;
+	}
+}
+
+// `ua` (the underlying JsSIP UserAgent) exists at runtime on SipClient but is
+// not declared in webitel-sdk's published types.
+declare module 'webitel-sdk' {
+	interface SipClient {
+		ua?: object;
+	}
+}
+
+declare global {
+	interface Window {
+		// Electron injects runtime config onto window before app init.
+		_config?: Record<string, unknown>;
+	}
+}

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,8 +1,7 @@
 import type { Breakpoint } from '@webitel/ui-sdk/plugins/breakpoint/breakpoint.plugin.js';
 
-// The breakpoint plugin injects `$breakpoint` as a Vue global property.
-// Re-declared here so it resolves without relying on the plugin's own
-// declaration file being pulled into the type graph.
+// Re-declared so `$breakpoint` resolves without pulling the plugin's own
+// declaration file into the type graph.
 declare module 'vue' {
 	interface ComponentCustomProperties {
 		$breakpoint: Breakpoint;
@@ -19,7 +18,6 @@ declare module 'webitel-sdk' {
 
 declare global {
 	interface Window {
-		// Electron injects runtime config onto window before app init.
 		_config?: Record<string, unknown>;
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@webitel/styleguide": "^26.2.16",
 				"@webitel/ui-chats": "^0.1.47",
 				"@webitel/ui-datalist": "^1.1.56",
-				"@webitel/ui-sdk": "^26.8",
+				"@webitel/ui-sdk": "~26.8",
 				"autolinker": "^4.x",
 				"axios": "1.18.1",
 				"deep-copy": "^1.x",
@@ -5797,9 +5797,9 @@
 			}
 		},
 		"node_modules/@webitel/api-services": {
-			"version": "0.1.46",
-			"resolved": "https://registry.npmjs.org/@webitel/api-services/-/api-services-0.1.46.tgz",
-			"integrity": "sha512-TfHP9t2jXv+ZqWqPFLogHtbtXremZaiaLB18hou8KrTmqcYzj8BY5z8IYufboNOcSy5wWODtERKKrfZbWLjlpQ==",
+			"version": "0.1.54",
+			"resolved": "https://registry.npmjs.org/@webitel/api-services/-/api-services-0.1.54.tgz",
+			"integrity": "sha512-nSNlYtNibXpP6rbSghze6/rldyG74xIQSpHnVisMGeJjVjT6rH7ZyjSnbz77bes8iHjXdzYXkMPr4J8/nsqdPQ==",
 			"dependencies": {
 				"@faker-js/faker": "^9.7.0",
 				"lodash-es": "^4.17.21",
@@ -5884,9 +5884,9 @@
 			}
 		},
 		"node_modules/@webitel/ui-sdk": {
-			"version": "26.8.5",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.8.5.tgz",
-			"integrity": "sha512-hupVZbdgjqPuUvf4kksZ+xcpmlvu7pse2SEJQ6aUd7dakK9UM0EZRvXSTniDxv+uXdU8gZvxhZ89aS9jgPMMGA==",
+			"version": "26.8.6",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.8.6.tgz",
+			"integrity": "sha512-KXJ8ofY2tvlza9Pa/hfypRVJyASxyzSajH/P5OAENjTVsx8J2+tPh6FhOOKAAcHFE9vzvRkIo1KNFQF/2gUnsA==",
 			"workspaces": [
 				"./packages/api-services",
 				"./packages/styleguide"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,9 @@
 				"@vueuse/core": "^14.x",
 				"@webitel/api-services": "^0.1.46",
 				"@webitel/styleguide": "^26.2.16",
-				"@webitel/ui-chats": "^0.1.41",
-				"@webitel/ui-sdk": "~26.6",
+				"@webitel/ui-chats": "^0.1.47",
+				"@webitel/ui-datalist": "^1.1.56",
+				"@webitel/ui-sdk": "^26.8",
 				"autolinker": "^4.x",
 				"axios": "1.18.1",
 				"deep-copy": "^1.x",
@@ -3274,6 +3275,115 @@
 				"node": ">=12.11.0"
 			}
 		},
+		"node_modules/@regle/core": {
+			"version": "1.28.4",
+			"resolved": "https://registry.npmjs.org/@regle/core/-/core-1.28.4.tgz",
+			"integrity": "sha512-eGOM+uGvvpVguxqONYACjjmKyORlLN80YaEfm8vEVOJfqi55eAfzwemdTeqMet3u0BKT4FUeV+tTMuXh8IVefg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@standard-schema/spec": "1.1.0",
+				"@vue/devtools-api": "7.7.9",
+				"type-fest": "5.7.0"
+			},
+			"peerDependencies": {
+				"pinia": ">=2.2.5",
+				"vue": ">=3.3.0"
+			},
+			"peerDependenciesMeta": {
+				"pinia": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@regle/core/node_modules/type-fest": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+			"integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+			"license": "(MIT OR CC0-1.0)",
+			"peer": true,
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@regle/rules": {
+			"version": "1.28.4",
+			"resolved": "https://registry.npmjs.org/@regle/rules/-/rules-1.28.4.tgz",
+			"integrity": "sha512-o69Y9U3qCjG29VSEjVlXBkbeqjPPkWH1vBUvoJlYwS1DZXuLvLbw/Kku5wkx1ugukCiiTGAlYd9quiM3wPb/+A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@regle/core": "1.28.4",
+				"type-fest": "5.7.0"
+			}
+		},
+		"node_modules/@regle/rules/node_modules/type-fest": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+			"integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+			"license": "(MIT OR CC0-1.0)",
+			"peer": true,
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@regle/schemas": {
+			"version": "1.28.4",
+			"resolved": "https://registry.npmjs.org/@regle/schemas/-/schemas-1.28.4.tgz",
+			"integrity": "sha512-ysqW/2rh2lDbHMnPKLiWzaz0H6gjJIof4JKahwZ1CqwGSDjXucU+cXEJ1SKK5cnaB2w7FtnI1hpAgQy8AvZ69A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@regle/core": "1.28.4",
+				"@regle/rules": "1.28.4",
+				"@standard-schema/spec": "1.1.0",
+				"type-fest": "5.7.0"
+			},
+			"peerDependencies": {
+				"arktype": "^2.1.0",
+				"valibot": "^1.0.0",
+				"zod": "^3.24.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"arktype": {
+					"optional": true
+				},
+				"valibot": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@regle/schemas/node_modules/type-fest": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+			"integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+			"license": "(MIT OR CC0-1.0)",
+			"peer": true,
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@rolldown/binding-android-arm64": {
 			"version": "1.0.0-rc.5",
 			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.5.tgz",
@@ -4085,7 +4195,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@tailwindcss/node": {
@@ -5714,9 +5823,9 @@
 			"integrity": "sha512-YfnxQBeIuLw6G55bq3dz1Q/zLoV+QH5zxoxgCOaQaugK/6oCOQqCDNUbdoX2lp8IZatt71g5607S+jig2sW4/w=="
 		},
 		"node_modules/@webitel/ui-chats": {
-			"version": "0.1.43",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-chats/-/ui-chats-0.1.43.tgz",
-			"integrity": "sha512-Zh0ZhDggbS5U09Sxf0EfsYVRcSnLMAqwvEUyoEeo936A/UrAuQOODwEfFiEXIvIVHMhiXrWQsUXm3263QW2O2g==",
+			"version": "0.1.47",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-chats/-/ui-chats-0.1.47.tgz",
+			"integrity": "sha512-ndHBtJ3gJgJDaGHVBqVqKm4MBkOmOjwuwWFxBxD3TjS9iBVCCyvWrt8xI/lhChYd7gGeSEnuALlO79eoUUA6rQ==",
 			"license": "ISC",
 			"workspaces": [
 				"../../",
@@ -5735,7 +5844,7 @@
 				"@webitel/api-services": "^0.1.0",
 				"@webitel/chat-web-sdk": "^0.0.19",
 				"@webitel/styleguide": "~26.2",
-				"@webitel/ui-sdk": "~26.6",
+				"@webitel/ui-sdk": "~26.8",
 				"mitt": "^3",
 				"vue": "^3.5"
 			},
@@ -5745,10 +5854,39 @@
 				}
 			}
 		},
+		"node_modules/@webitel/ui-datalist": {
+			"version": "1.1.56",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.56.tgz",
+			"integrity": "sha512-Sjxn4TdT4hRlLkFTBBXFtSc5nrRjZ7v6wYZ69KmAbetsnoO0EkLbUrqtsiqh3NJwD5x1ecARkhTaw57H9yPwLA==",
+			"license": "ISC",
+			"workspaces": [
+				"../../",
+				"../styleguide",
+				"../api-services"
+			],
+			"engines": {
+				"node": "v24",
+				"npm": "11"
+			},
+			"peerDependencies": {
+				"@regle/schemas": "^1.x",
+				"@vuelidate/core": "^2.0.3",
+				"@vuelidate/validators": "^2.0.4",
+				"@vueuse/core": "^14.0",
+				"@webitel/api-services": "^0.1.0",
+				"@webitel/styleguide": "~26.2",
+				"@webitel/ui-sdk": ">=26.2",
+				"axios": "^1.15.2",
+				"date-fns": "^4",
+				"pinia": "^3.x",
+				"vue": "^3.5",
+				"zod": "^4.x"
+			}
+		},
 		"node_modules/@webitel/ui-sdk": {
-			"version": "26.6.119",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.6.119.tgz",
-			"integrity": "sha512-+exABpmg1HvDoGx9Rqy5zijeXZmzJhAW0dRSY4ft9QzXyIGig/ZcpV5TwaAaHNO/N7VlqymiA6YPLWlHKZF2OQ==",
+			"version": "26.8.5",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.8.5.tgz",
+			"integrity": "sha512-hupVZbdgjqPuUvf4kksZ+xcpmlvu7pse2SEJQ6aUd7dakK9UM0EZRvXSTniDxv+uXdU8gZvxhZ89aS9jgPMMGA==",
 			"workspaces": [
 				"./packages/api-services",
 				"./packages/styleguide"
@@ -13292,6 +13430,19 @@
 			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/tagged-tag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+			"integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/tailwindcss": {
 			"version": "4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6459,9 +6459,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7802,9 +7802,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.11",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-			"integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+			"version": "3.4.12",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+			"integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -8393,9 +8393,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -9188,9 +9188,9 @@
 			"license": "MIT"
 		},
 		"node_modules/immutable": {
-			"version": "5.1.7",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.7.tgz",
-			"integrity": "sha512-47Xb+LFbZ/ZIjQMj6Q5J3IfK7PJFuqRdFOC9FpGgRTK6U2dAEVmkR9hp58qU4FpYux5YXpneDwkj2EP6lppzFA==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+			"integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
 			"devOptional": true,
 			"license": "MIT"
 		},
@@ -10395,9 +10395,9 @@
 			}
 		},
 		"node_modules/linkify-it": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-			"integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+			"integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -15289,16 +15289,16 @@
 			}
 		},
 		"node_modules/workbox-build/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/workbox-build/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@webitel/styleguide": "^26.2.16",
 		"@webitel/ui-chats": "^0.1.47",
 		"@webitel/ui-datalist": "^1.1.56",
-		"@webitel/ui-sdk": "^26.8",
+		"@webitel/ui-sdk": "~26.8",
 		"autolinker": "^4.x",
 		"axios": "1.18.1",
 		"deep-copy": "^1.x",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"prepare": "husky || true",
 		"biome:ci:gh": "biome ci ./src --reporter=github",
 		"test:unit:ci": "vitest run --coverage",
-		"typecheck:ci": "true"
+		"typecheck": "vue-tsc --noEmit -p ./tsconfig.json",
+		"typecheck:ci": "npm run typecheck"
 	},
 	"type": "module",
 	"dependencies": {
@@ -30,8 +31,9 @@
 		"@vueuse/core": "^14.x",
 		"@webitel/api-services": "^0.1.46",
 		"@webitel/styleguide": "^26.2.16",
-		"@webitel/ui-chats": "^0.1.41",
-		"@webitel/ui-sdk": "~26.6",
+		"@webitel/ui-chats": "^0.1.47",
+		"@webitel/ui-datalist": "^1.1.56",
+		"@webitel/ui-sdk": "^26.8",
 		"autolinker": "^4.x",
 		"axios": "1.18.1",
 		"deep-copy": "^1.x",

--- a/src/app/api/agent-workspace/websocket/useWebSocketClient.ts
+++ b/src/app/api/agent-workspace/websocket/useWebSocketClient.ts
@@ -69,7 +69,7 @@ function emit<K extends keyof EventMap>(
 	payload: Parameters<EventMap[K]>[0],
 ) {
 	listeners[event].forEach((cb) => {
-		cb(payload);
+		(cb as EventCallback)(payload);
 	});
 }
 
@@ -218,8 +218,11 @@ async function createClient(): Promise<Client> {
 	);
 
 	// why reactive? https://github.com/vuejs/core/discussions/7811#discussioncomment-5181921
-	cli.conversationStore = reactive(cli.conversationStore);
-	cli.callStore = reactive(cli.callStore);
+	// Bracket access: conversationStore/callStore are declared private on the
+	// webitel-sdk Client class, but this reactive-wrapping is an intentional
+	// documented pattern that must touch them from outside.
+	cli['conversationStore'] = reactive(cli['conversationStore']);
+	cli['callStore'] = reactive(cli['callStore']);
 
 	attachCoreHandlers(cli, generation);
 

--- a/src/app/api/agent-workspace/websocket/useWebSocketLatency.ts
+++ b/src/app/api/agent-workspace/websocket/useWebSocketLatency.ts
@@ -88,33 +88,29 @@ export const useWebSocketLatency = () => {
 			ConnectionQualityLevels.High;
 		const reasons: string[] = [];
 
-		const setLevel = (next: ConnectionQualityLevelsType) => {
-			level = next;
-		};
-
 		if (jitterAvg > 50) {
-			setLevel(ConnectionQualityLevels.Low);
+			level = ConnectionQualityLevels.Low;
 			reasons.push(`jitter ${Math.round(jitterAvg)} ms (> 50)`);
 		} else if (jitterAvg >= 30) {
-			setLevel(ConnectionQualityLevels.Medium);
+			level = ConnectionQualityLevels.Medium;
 			reasons.push(`jitter ${Math.round(jitterAvg)} ms (30–50)`);
 		}
 
 		if (packetLossAvg > 3) {
-			setLevel(ConnectionQualityLevels.Low);
+			level = ConnectionQualityLevels.Low;
 			reasons.push(`packet loss ${packetLossAvg.toFixed(1)} % (> 3%)`);
 		} else if (packetLossAvg > 1) {
-			setLevel(ConnectionQualityLevels.Medium);
+			level = ConnectionQualityLevels.Medium;
 			reasons.push(`packet loss ${packetLossAvg.toFixed(1)} % (1–3%)`);
 		}
 
 		const mosLevel = getConnectionQuality(mosAvg);
 
 		if (mosLevel === ConnectionQualityLevels.Low) {
-			setLevel(ConnectionQualityLevels.Low);
+			level = ConnectionQualityLevels.Low;
 			reasons.push(`MOS ${mosAvg.toFixed(2)} (< 3.5)`);
 		} else if (mosLevel === ConnectionQualityLevels.Medium) {
-			setLevel(ConnectionQualityLevels.Medium);
+			level = ConnectionQualityLevels.Medium;
 			reasons.push(`MOS ${mosAvg.toFixed(2)} (3.5–4.0)`);
 		}
 

--- a/src/app/assets/icons/sprite/index.ts
+++ b/src/app/assets/icons/sprite/index.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error він там є!
 import { fillIconsRepository } from '@webitel/ui-sdk';
 import protectionError from './protection-error.svg?raw';
 import wsAgent from './ws-agent.svg?raw';

--- a/src/app/composables/useInfiniteScroll.ts
+++ b/src/app/composables/useInfiniteScroll.ts
@@ -6,11 +6,37 @@ const DEFAULT_PAGE = 1;
 // 200px means it will start loading when the target element is 200px away from being visible
 const DEFAULT_LOAD_TRIGGER_DISTANCE = '200px';
 
+interface InfiniteScrollParams {
+	page: number;
+	size: number;
+	search: string;
+	fields?: unknown;
+	sort?: unknown;
+	filters?: unknown;
+}
+
+interface UseInfiniteScrollOptions<TItem> {
+	initialList?: TItem[];
+	size?: number;
+	initialSearch?: string;
+	loadTriggerDistance?: string;
+	fields?: unknown;
+	sort?: unknown;
+	filters?: unknown;
+	fetchFn: (params: InfiniteScrollParams) => Promise<{
+		items?: TItem[];
+		data?: TItem[];
+		next?: boolean;
+	}>;
+}
+
 /**
  * Composable that mirrors behavior of infiniteScrollMixin without modifying it.
  * Consumer must pass a fetchFn that returns { items?, data?, next }
  */
-export default function useInfiniteScroll(options = {}) {
+export default function useInfiniteScroll<TItem = unknown>(
+	options: UseInfiniteScrollOptions<TItem>,
+) {
 	const state = reactive({
 		dataList: options.initialList || [],
 		dataPage: DEFAULT_PAGE,
@@ -38,7 +64,7 @@ export default function useInfiniteScroll(options = {}) {
 	};
 
 	const collectParams = () => {
-		const params = {
+		const params: InfiniteScrollParams = {
 			page: state.dataPage,
 			size: state.dataSize,
 			search: state.dataSearch,

--- a/src/app/router/index.ts
+++ b/src/app/router/index.ts
@@ -37,7 +37,7 @@ export const initRouter = async ({
 	router = createRouter({
 		history: createWebHistory(import.meta.env.BASE_URL),
 
-		scrollBehavior(to, from, savedPosition) {
+		scrollBehavior() {
 			return {
 				left: 0,
 				top: 0,
@@ -51,7 +51,7 @@ export const initRouter = async ({
 		'error-page',
 	];
 
-	router.beforeEach((to, from, next) => {
+	router.beforeEach((to, _from, next) => {
 		if (excludeRouteAuth.includes(to.name)) {
 			next();
 			return;

--- a/src/features/modules/agent-status/statusUtils/getUserStatusByPriority.ts
+++ b/src/features/modules/agent-status/statusUtils/getUserStatusByPriority.ts
@@ -1,5 +1,4 @@
-import AbstractUserStatus from '@webitel/ui-sdk/src/enums/AbstractUserStatus/AbstractUserStatus.enum';
-import AgentStatus from '@webitel/ui-sdk/src/enums/AgentStatus/AgentStatus.enum';
+import { AbstractUserStatus, AgentStatus } from '@webitel/ui-sdk/enums';
 
 import parseUserStatus from './parseUserStatus';
 import UserStatus from './UserStatus';

--- a/src/ui/components/the-agent-workspace.vue
+++ b/src/ui/components/the-agent-workspace.vue
@@ -51,8 +51,7 @@
   lang="ts"
 >
 import { useCachedInterval } from '@webitel/ui-sdk/src/composables/useCachedInterval/useCachedInterval.js';
-import { storeToRefs } from 'pinia';
-import { computed, onUnmounted, provide, ref, watch } from 'vue';
+import { computed, onUnmounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useStore } from 'vuex';
 import { useAppNotification } from '../../features/modules/notifications/composables/useAppNotification';
@@ -64,11 +63,9 @@ import DescTrackAuthSuccessPopup from '../modules/popups/desc-track-auth-popup/c
 import DisconnectPopup from '../modules/popups/disconnect-popup/components/disconnect-popup.vue';
 import WelcomePopup from '../modules/popups/welcome-popup/welcome-popup.vue';
 import QueueSection from '../modules/queue-section/components/the-agent-queue-section.vue';
-import { useUserinfoStore } from '../modules/userinfo/userinfoStore';
 import VideoContainer from '../modules/video-container/components/video-container.vue';
 import WidgetBar from '../modules/widget-bar/components/widget-bar.vue';
 import WorkspaceSection from '../modules/work-section/components/the-agent-workspace-section.vue';
-import type { BrowserPermissions } from '../types/BrowserPermissions';
 
 const store = useStore();
 const route = useRoute();
@@ -91,8 +88,6 @@ const {
 const isInitLoading = ref(false);
 const isWelcomePopup = ref(true);
 const isDescTrackAuthSuccessPopup = ref(false);
-
-const userinfoStore = useUserinfoStore();
 
 const { subscribe } = useCachedInterval({
 	timeout: 5 * 1000,

--- a/src/ui/composables/usePanelSizeController.ts
+++ b/src/ui/composables/usePanelSizeController.ts
@@ -1,4 +1,4 @@
-import { ComponentSize } from '@webitel/ui-sdk/src/enums/ComponentSize/ComponentSize.ts';
+import { ComponentSize } from '@webitel/ui-sdk/enums';
 import { computed, getCurrentInstance, ref } from 'vue';
 
 export function usePanelSizeController() {

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-case-status-select.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-case-status-select.vue
@@ -28,12 +28,20 @@
     lang="ts"
 >
 import { WebitelCasesStatusCondition } from '@webitel/api-services/gen/models';
-import { WtIndicator, WtSingleSelect } from '@webitel/ui-sdk/components';
+import {
+	WtIndicator,
+	WtSingleSelect as WtSingleSelectBase,
+} from '@webitel/ui-sdk/components';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+// Barrel types components without slots; re-type via the component's declaration
+// (type-only `import(...)`, erased at runtime) for <template #value/#option>.
+const WtSingleSelect =
+	WtSingleSelectBase as unknown as typeof import('@webitel/ui-sdk/components/wt-single-select/wt-single-select.vue.js').default;
+
 const props = defineProps<{
-	value: WebitelCasesStatusCondition['id'];
+	value: WebitelCasesStatusCondition['id'] | WebitelCasesStatusCondition;
 	options: WebitelCasesStatusCondition[];
 }>();
 
@@ -45,7 +53,11 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
-const formattedValue = computed(() => props.value?.id || props.value);
+const formattedValue = computed(
+	() =>
+		(typeof props.value === 'object' ? props.value?.id : undefined) ||
+		props.value,
+);
 
 const selectedOption = computed(() =>
 	props.options.find((option) => option.id === formattedValue.value),

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-case-status-select.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-case-status-select.vue
@@ -28,8 +28,7 @@
     lang="ts"
 >
 import { WebitelCasesStatusCondition } from '@webitel/api-services/gen/models';
-import { WtIndicator } from '@webitel/ui-sdk/components';
-import WtSingleSelect from '@webitel/ui-sdk/components/wt-single-select/wt-single-select.vue';
+import { WtIndicator, WtSingleSelect } from '@webitel/ui-sdk/components';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-case-status-select.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-case-status-select.vue
@@ -28,17 +28,10 @@
     lang="ts"
 >
 import { WebitelCasesStatusCondition } from '@webitel/api-services/gen/models';
-import {
-	WtIndicator,
-	WtSingleSelect as WtSingleSelectBase,
-} from '@webitel/ui-sdk/components';
+import { WtIndicator } from '@webitel/ui-sdk/components';
+import WtSingleSelect from '@webitel/ui-sdk/components/wt-single-select/wt-single-select.vue';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-
-// Barrel types components without slots; re-type via the component's declaration
-// (type-only `import(...)`, erased at runtime) for <template #value/#option>.
-const WtSingleSelect =
-	WtSingleSelectBase as unknown as typeof import('@webitel/ui-sdk/components/wt-single-select/wt-single-select.vue.js').default;
 
 const props = defineProps<{
 	value: WebitelCasesStatusCondition['id'] | WebitelCasesStatusCondition;

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-select.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-select.vue
@@ -22,12 +22,12 @@
 
 <script setup lang="ts">
 import deepEqual from 'deep-equal';
-import { computed, onMounted, ref, watch, withDefaults } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 
 const props = withDefaults(
 	defineProps<{
-		value: never;
-		options?: never[];
+		value: unknown;
+		options?: SelectOption[];
 		multiple?: boolean;
 	}>(),
 	{
@@ -35,7 +35,7 @@ const props = withDefaults(
 	},
 );
 
-const emit = defineEmits<(e: 'input', value: never) => void>();
+const emit = defineEmits<(e: 'input', value: unknown) => void>();
 
 const initialValue = ref(null);
 const trackBy = computed(() => {

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/components/boolean-table-content.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/components/boolean-table-content.vue
@@ -8,8 +8,6 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue';
-
 interface Props {
 	value?: boolean;
 }

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/components/date-time-table-content.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/components/date-time-table-content.vue
@@ -7,7 +7,7 @@
 <script setup lang="ts">
 import { FormatDateMode } from '@webitel/ui-sdk/enums';
 import { formatDate } from '@webitel/ui-sdk/utils';
-import { computed, defineProps } from 'vue';
+import { computed } from 'vue';
 
 const props = defineProps({
 	value: {

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/components/link-table-content.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/components/link-table-content.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineProps } from 'vue';
+import { computed } from 'vue';
 
 interface Props {
 	value?: string | string[];

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/components/number-table-content.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/components/number-table-content.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineProps } from 'vue';
+import { computed } from 'vue';
 
 interface Props {
 	value?: string | number;

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/components/text-table-content.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/components/text-table-content.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineProps } from 'vue';
+import { computed } from 'vue';
 
 interface Props {
 	value?: string | string[];

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/processing-form-table.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/processing-form-table.vue
@@ -73,7 +73,7 @@ import {
 	snakeToCamel,
 } from '@webitel/api-services/api/transformers';
 import WtIntersectionObserver from '@webitel/ui-sdk/components/wt-intersection-observer/wt-intersection-observer.vue';
-import type { WtTableHeader } from '@webitel/ui-sdk/components/wt-table/types/WtTable.d.ts';
+import type { WtTableHeader } from '@webitel/ui-sdk/components/wt-table/types/WtTable';
 import {
 	ComponentSize,
 	ProcessingTableColumnType,

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/processing-form-table.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/processing-form-table.vue
@@ -99,8 +99,6 @@ import type {
 
 const { t } = useI18n();
 
-// Table headers carry the column `type` (used to pick the cell component)
-// on top of the base WtTableHeader shape.
 type TableHeader = WtTableHeader & {
 	type: string;
 };

--- a/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/processing-form-table.vue
+++ b/src/ui/modules/info-section/modules/processing/modules/form/components/components/processing-form-table/processing-form-table.vue
@@ -73,13 +73,13 @@ import {
 	snakeToCamel,
 } from '@webitel/api-services/api/transformers';
 import WtIntersectionObserver from '@webitel/ui-sdk/components/wt-intersection-observer/wt-intersection-observer.vue';
-import type { WtTableHeader } from '@webitel/ui-sdk/components/wt-table/types/WtTable';
+import type { WtTableHeader } from '@webitel/ui-sdk/components/wt-table/types/WtTable.d.ts';
 import {
 	ComponentSize,
 	ProcessingTableColumnType,
 } from '@webitel/ui-sdk/enums';
 import eventBus from '@webitel/ui-sdk/scripts/eventBus.js';
-import { computed, defineProps, onMounted, ref, useTemplateRef } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import TableApi from './api/table';
 import BooleanTableContent from './components/boolean-table-content.vue';
@@ -98,6 +98,12 @@ import type {
 } from './types/FormTable';
 
 const { t } = useI18n();
+
+// Table headers carry the column `type` (used to pick the cell component)
+// on top of the base WtTableHeader shape.
+type TableHeader = WtTableHeader & {
+	type: string;
+};
 
 const cellTableComponents = {
 	// components for each cell in table depending on type of value @author @liza-pohranichna
@@ -132,7 +138,6 @@ const nextAllowed = ref(false);
 const nextLoading = ref(false);
 const currentTablePage = ref(1);
 const dataList = ref<TableRow[]>([]);
-const infiniteScrollWrap = useTemplateRef('infiniteScrollWrap');
 
 const isSystemSource = computed<boolean>(() => props.table?.isSystemSource);
 const systemSourcePath = computed<string>(
@@ -161,7 +166,7 @@ const tableFields = computed<string[]>(() => {
 	]); // convert to snake case for API request before return
 });
 
-function isShowTypeComponent(item: TableRow, header: WtTableHeader): boolean {
+function isShowTypeComponent(item: TableRow, header: TableHeader): boolean {
 	return (
 		!!item[header.value] ||
 		item[header.value] === 0 || // we show type component, because 0 is valid value @author @liza-pohranichna
@@ -201,7 +206,7 @@ const tableColumns = computed<TableColumn[]>(() => {
 	});
 });
 
-const headers = computed<WtTableHeader[]>(() => {
+const headers = computed<TableHeader[]>(() => {
 	// headers for wt-table prop
 	return tableColumns.value.map((column) => ({
 		...column,

--- a/src/ui/modules/popups/desc-track-auth-popup/components/desc-track-auth-success-popup.vue
+++ b/src/ui/modules/popups/desc-track-auth-popup/components/desc-track-auth-success-popup.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineModel, ref } from 'vue';
+import { computed } from 'vue';
 import { useStore } from 'vuex';
 import DescTrackAuthSuccess from '../assets/desc-track-auth-success.svg';
 import DescTrackAuthSuccessDark from '../assets/desc-track-auth-success-dark.svg';

--- a/src/ui/modules/queue-section/components/the-agent-queue-section.vue
+++ b/src/ui/modules/queue-section/components/the-agent-queue-section.vue
@@ -17,8 +17,8 @@
       @change="currentTab = $event"
     >
       <template
-        v-for="(tab, key) of tabs"
-        :key="key"
+        v-for="tab of tabs"
+        :key="tab.value"
         #[tab.value]
       >
         <div
@@ -62,7 +62,14 @@
 </template>
 <script setup lang="ts">
 import { ComponentSize } from '@webitel/ui-sdk/enums';
-import { computed, markRaw, onMounted, onUnmounted, PropType, ref } from 'vue';
+import {
+	type Component,
+	computed,
+	markRaw,
+	onMounted,
+	onUnmounted,
+	ref,
+} from 'vue';
 import { useStore } from 'vuex';
 import { CallActions, ConversationState, JobState } from 'webitel-sdk';
 
@@ -92,7 +99,16 @@ const emit = defineEmits([
 ]);
 
 const store = useStore();
-const currentTab = ref({});
+interface QueueTab {
+	value: string;
+	icon: string;
+	iconColor: string;
+	countActive: number;
+	component: Component;
+	showIndicator: boolean;
+}
+
+const currentTab = ref<Partial<QueueTab>>({});
 const hotkeyUnsubscribers = ref([]);
 
 const callList = computed(() => store.state.features?.call?.callList || []);

--- a/src/ui/modules/video-container/components/video-container.vue
+++ b/src/ui/modules/video-container/components/video-container.vue
@@ -80,9 +80,22 @@ const screenshotData = ref<ScreenshotFileItem[]>([]);
 const videoContainerSize = ref<ComponentSize>(ComponentSize.SM);
 
 type WorkspaceCall = {
+	id?: string;
+	displayName?: string;
 	peerStreams?: MediaStream[];
 	localStreams?: MediaStream[];
-	[key: string]: unknown;
+	mutedVideo?: boolean;
+	recordings?: boolean;
+	remoteAudioMuted?: boolean;
+	screenshot?: () => Promise<
+		| {
+				blob: Blob;
+				file?: File;
+		  }
+		| undefined
+	>;
+	startRecord?: () => Promise<void> | void;
+	stopRecord?: () => Promise<void> | void;
 };
 
 const call = computed<WorkspaceCall>(

--- a/src/ui/modules/video-container/composable/useScreenshot.ts
+++ b/src/ui/modules/video-container/composable/useScreenshot.ts
@@ -10,7 +10,7 @@ type ScreenshotResult = {
 };
 
 type VideoCallScreenshot = {
-	screenshot: () => Promise<ScreenshotResult | undefined>;
+	screenshot?: () => Promise<ScreenshotResult | undefined>;
 	startRecord?: () => Promise<void> | void;
 	stopRecord?: () => Promise<void> | void;
 	close?: () => void;

--- a/src/ui/modules/work-section/modules/_shared/components/lookup-item/types/UserLookupItem.ts
+++ b/src/ui/modules/work-section/modules/_shared/components/lookup-item/types/UserLookupItem.ts
@@ -1,6 +1,7 @@
 export interface UserLookupItem {
 	id?: string | number;
 	name: string;
+	username?: string;
 	extension: string | number;
 	presence: {
 		status: string;

--- a/src/ui/modules/work-section/modules/_shared/components/lookup-item/user-lookup-item.vue
+++ b/src/ui/modules/work-section/modules/_shared/components/lookup-item/user-lookup-item.vue
@@ -32,7 +32,7 @@
 
 <script setup lang="ts">
 import { ComponentSize } from '@webitel/ui-sdk/enums';
-import { computed, defineEmits, defineProps, withDefaults } from 'vue';
+import { computed } from 'vue';
 import { getUserStatusByPriority } from '../../../../../../../features/modules/agent-status/statusUtils/getUserStatusByPriority';
 import LookupItem from './lookup-item.vue';
 import { UserLookupItem } from './types/UserLookupItem';

--- a/src/ui/modules/work-section/modules/_shared/components/task-header-expansion-card/task-header-expansion-card.vue
+++ b/src/ui/modules/work-section/modules/_shared/components/task-header-expansion-card/task-header-expansion-card.vue
@@ -41,22 +41,14 @@
 </template>
 
 <script setup lang="ts">
-import {
-	WtAvatar,
-	WtExpansionCard as WtExpansionCardBase,
-} from '@webitel/ui-sdk/components';
+import { WtAvatar } from '@webitel/ui-sdk/components';
+import WtExpansionCard from '@webitel/ui-sdk/components/wt-expansion-card/wt-expansion-card.vue';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useStore } from 'vuex';
 import { CallDirection } from 'webitel-sdk';
 import type { ChatContact } from '../../types/ChatContact.types';
 import QueueNameChip from '../queue-name-chip/queue-name-chip.vue';
-
-// The barrel types every component as a generic WtComponent with no slots.
-// Re-type via the component's own declaration (a type-only `import(...)`, erased
-// at runtime) so <template #header/#body> typecheck; runtime value is the barrel's.
-const WtExpansionCard =
-	WtExpansionCardBase as unknown as typeof import('@webitel/ui-sdk/components/wt-expansion-card/wt-expansion-card.vue.js').default;
 
 const store = useStore();
 

--- a/src/ui/modules/work-section/modules/_shared/components/task-header-expansion-card/task-header-expansion-card.vue
+++ b/src/ui/modules/work-section/modules/_shared/components/task-header-expansion-card/task-header-expansion-card.vue
@@ -41,8 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { WtAvatar } from '@webitel/ui-sdk/components';
-import WtExpansionCard from '@webitel/ui-sdk/components/wt-expansion-card/wt-expansion-card.vue';
+import { WtAvatar, WtExpansionCard } from '@webitel/ui-sdk/components';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useStore } from 'vuex';

--- a/src/ui/modules/work-section/modules/_shared/components/task-header-expansion-card/task-header-expansion-card.vue
+++ b/src/ui/modules/work-section/modules/_shared/components/task-header-expansion-card/task-header-expansion-card.vue
@@ -12,13 +12,13 @@
 
         <div class="task-header-expansion-card__title">
           <a
-            v-if="username?.contactName && contactLink"
+            v-if="displayName?.contactName && contactLink"
             :href="contactLink"
             target="_blank"
             class="task-header-expansion-card__link">
-            {{ username?.contactName }}</a>
+            {{ displayName?.contactName }}</a>
           <span
-            v-if="!isChat || username?.extraNames"
+            v-if="!isChat || displayName?.extraNames"
             class="task-header-expansion-card__extra"
           >{{ taskTitle }}</span>
         </div>
@@ -41,7 +41,10 @@
 </template>
 
 <script setup lang="ts">
-import { WtAvatar, WtExpansionCard } from '@webitel/ui-sdk/components';
+import {
+	WtAvatar,
+	WtExpansionCard as WtExpansionCardBase,
+} from '@webitel/ui-sdk/components';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useStore } from 'vuex';
@@ -49,11 +52,23 @@ import { CallDirection } from 'webitel-sdk';
 import type { ChatContact } from '../../types/ChatContact.types';
 import QueueNameChip from '../queue-name-chip/queue-name-chip.vue';
 
+// The barrel types every component as a generic WtComponent with no slots.
+// Re-type via the component's own declaration (a type-only `import(...)`, erased
+// at runtime) so <template #header/#body> typecheck; runtime value is the barrel's.
+const WtExpansionCard =
+	WtExpansionCardBase as unknown as typeof import('@webitel/ui-sdk/components/wt-expansion-card/wt-expansion-card.vue.js').default;
+
 const store = useStore();
+
+interface DisplayChatName {
+	contactName?: string | null;
+	extraNames?: string;
+	fullName?: string;
+}
 
 const props = withDefaults(
 	defineProps<{
-		username: string;
+		username: string | DisplayChatName;
 		phoneNumber?: string;
 		queueName?: string;
 		contact?: ChatContact;
@@ -74,15 +89,18 @@ const props = withDefaults(
 
 const { t } = useI18n();
 
+const displayName = computed<DisplayChatName | null>(() =>
+	typeof props.username === 'object' && props.username ? props.username : null,
+);
+
 const chatTitle = computed(() => {
-	if (props.username?.extraNames) {
-		return (
-			(props.username?.contactName ? ', ' : '') + props.username.extraNames
-		);
-	} else if (props.username?.fullName === 'unknown') {
+	const name = displayName.value;
+	if (name?.extraNames) {
+		return (name.contactName ? ', ' : '') + name.extraNames;
+	} else if (name?.fullName === 'unknown') {
 		return t('workspaceSec.taskHeaderExpansionCard.unknownContact');
 	}
-	return props.username?.fullName;
+	return name?.fullName;
 });
 
 const taskTitle = computed(() => {
@@ -94,7 +112,10 @@ const taskTitle = computed(() => {
 });
 
 const avatarTitle = computed(
-	() => props.contact?.name || props.username?.fullName || props.username,
+	() =>
+		props.contact?.name ||
+		displayName.value?.fullName ||
+		(typeof props.username === 'string' ? props.username : ''),
 );
 
 const contactLink = computed(() =>

--- a/src/ui/modules/work-section/modules/call/components/call-footer.vue
+++ b/src/ui/modules/work-section/modules/call/components/call-footer.vue
@@ -53,7 +53,7 @@
 
 <script lang="ts" setup>
 import { ButtonVariant, ComponentSize } from '@webitel/ui-sdk/enums';
-import { computed, onMounted, onUnmounted, ref, withDefaults } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useStore } from 'vuex';
 import HotkeyAction from '../../../../../hotkeys/HotkeysActiom.enum';
 import { useHotkeys } from '../../../../../hotkeys/useHotkeys';

--- a/src/ui/modules/work-section/modules/call/components/call-state.vue
+++ b/src/ui/modules/work-section/modules/call/components/call-state.vue
@@ -24,7 +24,6 @@
         >
           {{ digit }}
         </span>
-        {{ digit }}
       </span>
     </div>
     <div

--- a/src/ui/modules/work-section/modules/call/components/call-transfer/_shared/components/call-transfer-container.vue
+++ b/src/ui/modules/work-section/modules/call/components/call-transfer/_shared/components/call-transfer-container.vue
@@ -51,6 +51,7 @@ import { ComponentSize } from '@webitel/ui-sdk/enums';
 import { computed } from 'vue';
 import useInfiniteScroll from '../../../../../../../../../app/composables/useInfiniteScroll';
 import TransferLookupItem from '../../../../../_shared/components/lookup-item/transfer-lookup-item.vue';
+import type { TransferItem } from '../../../../../_shared/components/lookup-item/types/transfer-lookup-item';
 import LookupItemContainer from '../../../../../_shared/components/lookup-item-container/lookup-item-container.vue';
 import EmptySearch from '../../../../../_shared/components/workspace-empty-search/components/empty-search.vue';
 import TransferDestination from '../../../../../chat/enums/ChatTransferDestination.enum.js';
@@ -87,10 +88,16 @@ const props = withDefaults(defineProps<CallTransferContainerProps>(), {
 
 const emit = defineEmits<CallTransferContainerEmits>();
 
-const scroll = useInfiniteScroll({
+const scroll = useInfiniteScroll<TransferItem>({
 	filters: props.dataFilters,
 	fields: props.dataFields,
-	fetchFn: (params) => props.getData(params),
+	// useInfiniteScroll builds a generic param bag; getData wants the
+	// tab-specific TransferParams shape. They are structurally different bags,
+	// so bridge explicitly.
+	fetchFn: (params) =>
+		props.getData(params as unknown as TransferParams) as Promise<{
+			items?: TransferItem[];
+		}>,
 });
 
 const isTransferToNumberDisabled = computed(() => !scroll.dataSearch.value);

--- a/src/ui/modules/work-section/modules/call/components/call-transfer/components/agents-call-transfer.vue
+++ b/src/ui/modules/work-section/modules/call/components/call-transfer/components/agents-call-transfer.vue
@@ -28,7 +28,6 @@ import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 import { useStore } from 'vuex';
 
-import APIRepository from '../../../../../../../../app/api/APIRepository';
 import { useLoader } from '../../../../../../../composables/useLoader';
 import { useUserinfoStore } from '../../../../../../userinfo/userinfoStore';
 import CallTransferContainer from '../_shared/components/call-transfer-container.vue';
@@ -43,7 +42,6 @@ interface APIResponse {
 const store = useStore();
 const { showLoader, runWithLoader } = useLoader();
 
-const agentsAPI = APIRepository.agents;
 const PresenceStatusField = 'userPresenceStatus';
 
 const dataFields = [
@@ -59,14 +57,6 @@ const dataSort = 'position';
 
 const currentTranferLoaderId = ref<string | null>(null);
 
-const scroll = computed(
-	() =>
-		store.state.scroll || {
-			dataSearch: {
-				value: '',
-			},
-		},
-);
 const call = computed(() => store.getters['features/call/CALL_ON_WORKSPACE']);
 const userinfoStore = useUserinfoStore();
 const { userId } = storeToRefs(userinfoStore);

--- a/src/ui/modules/work-section/modules/call/components/call-transfer/the-call-transfer.vue
+++ b/src/ui/modules/work-section/modules/call/components/call-transfer/the-call-transfer.vue
@@ -19,14 +19,12 @@ import { ComponentSize } from '@webitel/ui-sdk/enums';
 import { WebitelLicense } from '@webitel/ui-sdk/modules/Userinfo';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useStore } from 'vuex';
 import { useUserinfoStore } from '../../../../../../modules/userinfo/userinfoStore';
 import AgentsCallTransfer from './components/agents-call-transfer.vue';
 import QueuesCallTransfer from './components/queues-call-transfer.vue';
 import UsersCallTransfer from './components/users-call-transfer.vue';
 
 const { t } = useI18n();
-const store = useStore();
 
 interface CallTransferTabsProps {
 	size: ComponentSize;

--- a/src/ui/modules/work-section/modules/call/module/video-call/module/chat/components/the-video-call-chat.vue
+++ b/src/ui/modules/work-section/modules/call/module/video-call/module/chat/components/the-video-call-chat.vue
@@ -32,7 +32,7 @@ import { useUserinfoStore } from '../../../../../../../../userinfo/userinfoStore
 
 const props = withDefaults(
 	defineProps<{
-		size?: string;
+		size?: ComponentSize;
 	}>(),
 	{
 		size: ComponentSize.MD,

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/autocomplete/composables/useAutocomplete.ts
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/autocomplete/composables/useAutocomplete.ts
@@ -1,6 +1,7 @@
-import { computed, ref } from 'vue';
+import { computed, type Ref, ref } from 'vue';
+import type { ChatHelperItem } from '../../types/ChatHelperItem.types';
 
-export function useAutocomplete(options = []) {
+export function useAutocomplete(options: Ref<ChatHelperItem[]> = ref([])) {
 	const isOpenAutocomplete = ref(false);
 	const search = ref('');
 

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/chat-messaging.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/chat-messaging.vue
@@ -109,16 +109,9 @@
 import { WebitelContactsContact } from '@webitel/api-services/gen';
 import { WtChatEmoji } from '@webitel/ui-sdk/components';
 import { ComponentSize } from '@webitel/ui-sdk/enums';
+import { eventBus } from '@webitel/ui-sdk/scripts';
 import insertTextAtCursor from 'insert-text-at-cursor';
-import {
-	computed,
-	inject,
-	nextTick,
-	onMounted,
-	onUnmounted,
-	ref,
-	watch,
-} from 'vue';
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useStore } from 'vuex';
 
@@ -134,6 +127,7 @@ import ChatHelperList from './components/chat-helper-list.vue';
 import CurrentChat from './current-chat/current-chat.vue';
 import { useQuickReplies } from './quick-replies/composables/useQuickReplies';
 import QuickReplies from './quick-replies/quick-replies.vue';
+import type { ChatHelperItem } from './types/ChatHelperItem.types';
 
 const props = withDefaults(
 	defineProps<{
@@ -155,7 +149,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const eventBus = inject('$eventBus');
 const store = useStore();
 
 const messageDraft = ref();
@@ -285,7 +278,7 @@ function handleFilePaste(event: ClipboardEvent) {
 }
 
 async function handleAttachments(event: Event) {
-	const files = Array.from(event.target.files);
+	const files = Array.from((event.target as HTMLInputElement).files ?? []);
 	await sendFile(files);
 }
 
@@ -303,7 +296,7 @@ function applyQuickReply({ text }) {
 	setDraftFocus();
 }
 
-function selectAutocompleteOption({ id }: { id: string }) {
+function selectAutocompleteOption({ id }: ChatHelperItem) {
 	switch (id) {
 		case AutocompleteOptions.QUICK_REPLIES:
 			showQuickRepliesPanel();

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/chat-messaging.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/chat-messaging.vue
@@ -109,7 +109,7 @@
 import { WebitelContactsContact } from '@webitel/api-services/gen';
 import { WtChatEmoji } from '@webitel/ui-sdk/components';
 import { ComponentSize } from '@webitel/ui-sdk/enums';
-import { eventBus } from '@webitel/ui-sdk/scripts';
+import { useEventBus } from '@webitel/ui-sdk/composables';
 import insertTextAtCursor from 'insert-text-at-cursor';
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -150,6 +150,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 const store = useStore();
+const eventBus = useEventBus();
 
 const messageDraft = ref();
 const attachmentInput = ref();

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/chat-messaging.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/chat-messaging.vue
@@ -108,8 +108,8 @@
 <script setup lang="ts">
 import { WebitelContactsContact } from '@webitel/api-services/gen';
 import { WtChatEmoji } from '@webitel/ui-sdk/components';
-import { ComponentSize } from '@webitel/ui-sdk/enums';
 import { useEventBus } from '@webitel/ui-sdk/composables';
+import { ComponentSize } from '@webitel/ui-sdk/enums';
 import insertTextAtCursor from 'insert-text-at-cursor';
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/components/chat-helper-list.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/components/chat-helper-list.vue
@@ -29,7 +29,13 @@
 
 </template>
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from 'vue';
+import {
+	type ComponentPublicInstance,
+	onMounted,
+	onUnmounted,
+	ref,
+	watch,
+} from 'vue';
 import { ChatHelperItem } from '../types/ChatHelperItem.types';
 
 const props = defineProps<{
@@ -53,8 +59,11 @@ const select = (item) => {
 	emit('select', item);
 };
 
-const setItemRef = (el: HTMLElement | null, index: number) => {
-	if (el) itemRefs.value[index] = el;
+const setItemRef = (
+	el: Element | ComponentPublicInstance | null,
+	index: number,
+) => {
+	if (el instanceof HTMLElement) itemRefs.value[index] = el;
 };
 
 const moveDown = () => {

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/message/components/chat-message-player.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/message/components/chat-message-player.vue
@@ -34,6 +34,7 @@
 import { type ChatMessageFile, useChatMessageFile } from '@webitel/ui-chats/ui';
 import { WtPlayer, WtVidstackPlayer } from '@webitel/ui-sdk/components';
 import { ComponentSize } from '@webitel/ui-sdk/enums';
+import type { MediaSrc } from 'vidstack';
 import { computed } from 'vue';
 
 const props = defineProps<{
@@ -51,14 +52,19 @@ const emit = defineEmits<{
 
 const { media } = useChatMessageFile(props.file);
 
-const mediaSrcObject = computed(() => ({
-	src: media.value?.streamUrl || media.value?.url,
-	type: media.value?.mime,
-}));
+// vidstack's MediaSrc unions require a specific MimeType literal for `type`;
+// the mime here is a dynamic server string, which vidstack accepts at runtime.
+const mediaSrcObject = computed(
+	() =>
+		({
+			src: media.value?.streamUrl || media.value?.url,
+			type: media.value?.mime,
+		}) as MediaSrc,
+);
 
 const isVideo = computed(() => media.value?.mime?.includes('video'));
 
-function handlePlayerInitialize(player: unknown) {
+function handlePlayerInitialize(player?: unknown) {
 	emit('initialized', player);
 }
 </script>

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/message/components/chat-message-player.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/message/components/chat-message-player.vue
@@ -40,7 +40,10 @@ const props = defineProps<{
 	file: ChatMessageFile;
 }>();
 
-const emit = defineEmits<(e: 'initialized', player: unknown) => void>();
+const emit = defineEmits<{
+	(e: 'initialized', player: unknown): void;
+	(e: 'open', media: unknown): void;
+}>();
 
 const { media } = useChatMessageFile(props.file);
 

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/message/components/chat-message-player.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/message/components/chat-message-player.vue
@@ -41,8 +41,12 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-	(e: 'initialized', player: unknown): void;
-	(e: 'open', media: unknown): void;
+	initialized: [
+		player: unknown,
+	];
+	open: [
+		media: unknown,
+	];
 }>();
 
 const { media } = useChatMessageFile(props.file);

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/quick-replies/composables/useQuickReplies.ts
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/quick-replies/composables/useQuickReplies.ts
@@ -29,7 +29,7 @@ export function useQuickReplies({
 
 	function replaceVariables(text: string): string {
 		return text.replace(VARIABLES_REGEX, (match, varName) => {
-			return variables[varName] ?? match;
+			return String(variables[varName] ?? match);
 		});
 	}
 

--- a/src/ui/modules/work-section/modules/job/components/job-header/job-header.vue
+++ b/src/ui/modules/work-section/modules/job/components/job-header/job-header.vue
@@ -13,6 +13,7 @@
 <script setup lang="ts">
 import { ComponentSize } from '@webitel/ui-sdk/enums';
 import { computed } from 'vue';
+import type { Task } from 'webitel-sdk';
 import { getQueueName } from '../../../../../../modules/queue-section/modules/_shared/scripts/getQueueName';
 import TaskHeader from '../../../_shared/components/task-header/task-header.vue';
 import TaskHeaderExpansionCard from '../../../_shared/components/task-header-expansion-card/task-header-expansion-card.vue';
@@ -20,7 +21,7 @@ import TaskHeaderExpansionCard from '../../../_shared/components/task-header-exp
 const props = withDefaults(
 	defineProps<{
 		size?: ComponentSize;
-		task: object;
+		task: Task;
 	}>(),
 	{
 		size: ComponentSize.MD,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,19 @@
 		"skipLibCheck": true,
 
 		"moduleResolution": "Bundler",
+		"baseUrl": ".",
+		"paths": {
+			// ui-sdk components ship source `.vue` (which vue-tsc would typecheck)
+			// alongside compiled `.vue.d.ts` under `types/`. A deep component
+			// import resolves to the source and leaks the SDK's own type errors,
+			// so map deep component paths to the shipped declarations first,
+			// falling back to source only when no `.d.ts` exists. Runtime is
+			// unaffected — Vite resolves via the package `exports`, not tsconfig.
+			"@webitel/ui-sdk/components/*": [
+				"./node_modules/@webitel/ui-sdk/types/components/*",
+				"./node_modules/@webitel/ui-sdk/src/components/*"
+			]
+		},
 		"isolatedModules": true,
 		"moduleDetection": "force",
 		"noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,40 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "lib": ["esnext", "DOM"],
-    "plugins": [{ "name": "typescript-plugin-css-modules" }],
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"lib": [
+			"esnext",
+			"DOM"
+		],
+		"plugins": [
+			{
+				"name": "typescript-plugin-css-modules"
+			}
+		],
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
 
-    "allowJs": false,
-    "skipLibCheck": true,
+		"allowJs": false,
+		"skipLibCheck": true,
 
-    "moduleResolution": "Bundler",
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "noEmitOnError": false,
+		"moduleResolution": "Bundler",
+		"isolatedModules": true,
+		"moduleDetection": "force",
+		"noEmit": true,
+		"noEmitOnError": false,
 
-    "strict": false,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
-  },
-  "include": ["src", "declarations.d.ts"]
+		"strict": false,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": true
+	},
+	"include": [
+		"src",
+		"declarations.d.ts"
+	],
+	"exclude": [
+		"**/*.spec.ts",
+		"**/*.test.ts"
+	]
 }


### PR DESCRIPTION
## Summary
Drives the project's TypeScript error count from **121 → 0** with type-level fixes only (no runtime behavior changes), and wires up a real typecheck command so CI catches future regressions.

Jira: [WTEL-9942](https://webitel.atlassian.net/browse/WTEL-9942)

## What changed
- **Dependencies**: `@webitel/ui-sdk` `~26.6` → `^26.8` (fixes broken `./src/types` export + missing wt-table `.d.ts` at the source); add missing `@webitel/ui-datalist` dep. `@webitel/ui-chats` bump incidentally fixed its stale types barrel.
- **Baseline enforcement**: added real `typecheck` script; replaced the `"typecheck:ci": "true"` stub with `npm run typecheck`; `tsconfig` now excludes `*.spec.ts`/`*.test.ts` (specs run via vitest with `globals:true`).
- **Fixes by cluster**: removed Vue compiler macros wrongly imported from `'vue'`; removed unused locals/imports; fixed module-resolution paths (enums barrel, `.ts` extension); corrected property-access types (webitel-sdk `Task`/`Call` instead of `object`/loose local types, `DisplayChatName`/`UserLookupItem` unions, typed `eventBus` import, `HTMLInputElement`/`Element` casts, generic `useInfiniteScroll`/`useAutocomplete`); added `declarations.d.ts` augmentations (`$breakpoint`, `window._config`, `SipClient.ua`); inlined a closure assignment in `useWebSocketLatency` so control-flow keeps the union.

## Notable casts / escape hatches (for review)
- `useWebSocketClient.ts`: `(cb as EventCallback)` dynamic dispatch; bracket access `cli['conversationStore']`/`['callStore']` to touch webitel-sdk private fields (intentional reactive-wrap pattern).
- `call-transfer-container.vue`: `params as unknown as TransferParams` bridging the generic scroll param-bag.
- `task-header-expansion-card.vue` / `processing-form-case-status-select.vue`: re-type barrel components via type-only `typeof import('…vue.js').default` — because the ui-sdk **components barrel types every component as a slot-less generic `WtComponent`**. Real root fix belongs in ui-sdk.
- `declarations.d.ts`: augments webitel-sdk `SipClient.ua` (exists at runtime, undeclared upstream).

## Verification
- `npm run typecheck` → exit 0
- `npx vitest run` → **114 files / 359 tests pass**
- `npx biome check ./src` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WTEL-9942]: https://webitel.atlassian.net/browse/WTEL-9942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ