### PR TITLE
fix: prevent mark closed chat as read if it was not[WTEL-10003]

### DIFF
--- a/src/features/modules/chat/modules/closed/store/closed.js
+++ b/src/features/modules/chat/modules/closed/store/closed.js
@@ -82,10 +82,6 @@ const actions = {
 		}
 	},
 	OPEN_CLOSED_CHAT: async (context, chat) => {
-		context.commit('features/chat/unseen/REMOVE_UNSEEN_CHAT', chat, {
-			root: true,
-		});
-
 		if (!chat.contact?.id) {
 			await context.dispatch('LOAD_CLOSED_CHAT', chat);
 		} else {

--- a/src/features/modules/chat/store/chat.js
+++ b/src/features/modules/chat/store/chat.js
@@ -99,7 +99,6 @@ const actions = {
 
 	CLOSE: async (context) => {
 		const chatOnWorkspace = context.getters.CHAT_ON_WORKSPACE;
-		context.commit('unseen/REMOVE_UNSEEN_CHAT', chatOnWorkspace);
 		if (chatOnWorkspace.allowLeave) {
 			await chatOnWorkspace.leave();
 		} else {

--- a/src/ui/modules/work-section/modules/chat/chat-messaging/chat-history/the-chat-history.vue
+++ b/src/ui/modules/work-section/modules/chat/chat-messaging/chat-history/the-chat-history.vue
@@ -106,7 +106,7 @@ const store = useStore();
 const chatNamespace = 'features/chat';
 const namespace = `${chatNamespace}/chatHistory`;
 
-const OBSERVER_TIMEOUT_MS = 1500;
+const OBSERVER_TIMEOUT_MS = 3000;
 
 const chatContainer = useTemplateRef('chat-container');
 const chatContent = useTemplateRef('chat-content');
@@ -142,6 +142,7 @@ const {
 	showScrollToBottomBtn,
 	newUnseenMessagesCount,
 	scrollToBottom,
+	markSeenIfAtBottom,
 	handleChatScroll,
 } = useChatScroll({
 	chatContainer,
@@ -177,7 +178,10 @@ const { startObserve } = useObserveHeightUntilStable(
  */
 const { startObserve: startObserveClosedChat } = useObserveHeightUntilStable(
 	chatContent,
-	() => closedChatAnchorEl.value?.scrollIntoView(true),
+	() => {
+		closedChatAnchorEl.value?.scrollIntoView(true);
+		markSeenIfAtBottom();
+	},
 	OBSERVER_TIMEOUT_MS,
 );
 


### PR DESCRIPTION
## Уточнені вимоги
Мітка знімається лише коли оператор дійсно бачить останні повідомлення. Короткий закритий чат, що вміщується у вікно цілком, має зніматися одразу, бо все видно; довгий закритий відкривається на якорі вгорі - мітка лишається до доскролу вниз. Через ці уточнені вимоги прибрала зняття чату як непрочитаного при закритті чату та відкритті закритого чату.