### PR TITLE
fix(electron): use runtime require in renderer [WTEL-9408]

### DIFF
--- a/packages/electron-workspace/src/renderer/shared/i18n.ts
+++ b/packages/electron-workspace/src/renderer/shared/i18n.ts
@@ -7,15 +7,31 @@ declare global {
 		electronStorage?: {
 			getItem: (k: string) => string | null;
 		};
+		/** Electron renderer Node require (nodeIntegration: true). */
+		require?: NodeRequire;
+	}
+}
+
+/**
+ * Read lang from electron-localstorage via Electron's runtime require.
+ * Do NOT use a bare `require('electron-localstorage')` — Vite bundles that
+ * package and stubs Node `path`/`fs` as `{}`, so `path.join` throws at runtime.
+ */
+function readStoredLang(): string | null {
+	try {
+		const fromWindow = window.electronStorage?.getItem?.('lang');
+		if (fromWindow != null && fromWindow !== '') return fromWindow;
+
+		const nodeRequire = window.require;
+		if (typeof nodeRequire !== 'function') return null;
+		return nodeRequire('electron-localstorage').getItem('lang') ?? null;
+	} catch {
+		return null;
 	}
 }
 
 function detectLocale(): Locale {
-	const stored =
-		window.electronStorage?.getItem?.('lang') ||
-		(typeof require === 'function'
-			? require('electron-localstorage').getItem('lang')
-			: null);
+	const stored = readStoredLang();
 	if (stored === 'ru' || stored === 'uk' || stored === 'en') return stored;
 	return 'en';
 }

--- a/packages/electron-workspace/src/renderer/shared/ipc.ts
+++ b/packages/electron-workspace/src/renderer/shared/ipc.ts
@@ -1,0 +1,16 @@
+import type { IpcRenderer } from 'electron';
+
+/**
+ * Electron ipcRenderer via runtime Node require (nodeIntegration: true).
+ * Bare `require('electron')` is resolved by Vite to the npm `electron`
+ * package, which gets stubbed `path`/`fs` and breaks at runtime.
+ */
+export function getIpcRenderer(): IpcRenderer | null {
+	try {
+		const nodeRequire = window.require;
+		if (typeof nodeRequire !== 'function') return null;
+		return nodeRequire('electron').ipcRenderer as IpcRenderer;
+	} catch {
+		return null;
+	}
+}

--- a/packages/electron-workspace/src/renderer/windows/call/composables/useCallIPC.ts
+++ b/packages/electron-workspace/src/renderer/windows/call/composables/useCallIPC.ts
@@ -1,7 +1,6 @@
-import type { IpcRenderer } from 'electron';
+import { getIpcRenderer } from '../../../shared/ipc';
 
-const ipcRenderer: IpcRenderer | null =
-	typeof require === 'function' ? require('electron').ipcRenderer : null;
+const ipcRenderer = getIpcRenderer();
 
 export type CallPayload = {
 	id?: string | number;

--- a/packages/electron-workspace/src/renderer/windows/disconnect/components/DisconnectView.vue
+++ b/packages/electron-workspace/src/renderer/windows/disconnect/components/DisconnectView.vue
@@ -20,12 +20,12 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
+import { getIpcRenderer } from '../../../shared/ipc';
 import iconDisconnect from '../assets/disconnect-img.svg';
 
 const { t } = useI18n();
 
-const ipcRenderer =
-	typeof require === 'function' ? require('electron').ipcRenderer : null;
+const ipcRenderer = getIpcRenderer();
 
 function connect() {
 	ipcRenderer?.send('reload-page');

--- a/packages/electron-workspace/src/renderer/windows/load-config/components/LoadConfigView.vue
+++ b/packages/electron-workspace/src/renderer/windows/load-config/components/LoadConfigView.vue
@@ -23,11 +23,11 @@
 import { onMounted, onUnmounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import iconApp from '@img/app-icon.svg';
+import { getIpcRenderer } from '../../../shared/ipc';
 
 const { t } = useI18n();
 
-const ipcRenderer =
-	typeof require === 'function' ? require('electron').ipcRenderer : null;
+const ipcRenderer = getIpcRenderer();
 
 function uploadFile() {
 	ipcRenderer?.send('file-open');


### PR DESCRIPTION
## Summary
- Stop Vite from bundling `electron-localstorage` / npm `electron` into renderer (stubs Node `path`/`fs` as `{}` → `path.join is not a function` on Windows)
- Load those modules via `window.require` at runtime (`nodeIntegration: true`)
- Shared `getIpcRenderer()` helper for call / load-config / disconnect windows

## Test plan
- [ ] Rebuild Windows electron-workspace artifact
- [ ] Install and launch — err-message / load-config windows open without `path.join` console error
- [ ] Locale still reads from electron-localstorage when set
- [ ] Call / disconnect / load-config IPC actions still work
- [ ] Mac arm64 build still starts

[WTEL-9408](https://webitel.atlassian.net/browse/WTEL-9408)


Made with [Cursor](https://cursor.com)

[WTEL-9408]: https://webitel.atlassian.net/browse/WTEL-9408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ