### PR TITLE
fix(electron): make macOS open-at-login reliable [DEV-6800]

### DIFF
--- a/packages/electron-workspace/src/main/index.js
+++ b/packages/electron-workspace/src/main/index.js
@@ -119,18 +119,29 @@ autoUpdater.on('update-downloaded', () => {
 app.on('ready', () => {
 	require('./module/webitel_login_item').syncFromConfig();
 
-	if (conf.updateEndpoint && isValidUrl(conf.updateEndpoint)) {
-		autoUpdater.setFeedURL(conf.updateEndpoint);
-		autoUpdater.checkForUpdatesAndNotify().then(() => {
-			win.start();
-			createAndSubscribeTray();
-			subscribePowerMonitor();
-		});
-	} else {
+	const startApp = () => {
 		win.start();
 		createAndSubscribeTray();
 		subscribePowerMonitor();
+		// macOS login / TAL restore can leave windows hidden — force on-screen.
+		setTimeout(() => win.restoreWindow(), 300);
+	};
+
+	if (conf.updateEndpoint && isValidUrl(conf.updateEndpoint)) {
+		autoUpdater.setFeedURL(conf.updateEndpoint);
+		autoUpdater.checkForUpdatesAndNotify().then(startApp);
+	} else {
+		startApp();
 	}
+});
+
+app.on('activate', () => {
+	if (win.workspace?.window || win.loadConfig?.window) {
+		win.restoreWindow();
+		return;
+	}
+	win.start();
+	setTimeout(() => win.restoreWindow(), 100);
 });
 
 ipcMain.handle('get-userData-path', async (event) => {

--- a/packages/electron-workspace/src/main/module/webitel_login_item.js
+++ b/packages/electron-workspace/src/main/module/webitel_login_item.js
@@ -1,19 +1,177 @@
-const { app } = require('electron');
-const { isLinux, isWindows } = require('../../shared/is');
+const { app, dialog, shell } = require('electron');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { isLinux, isWindows, isOSX } = require('../../shared/is');
 const { config, updateConfig } = require('../../shared/config');
+
+const LAUNCH_AGENT_LABEL = 'org.webitel.openAtLogin';
 
 /** macOS + Windows only — Electron has no login-item API on Linux. */
 const isSupported = () => !isLinux;
 
 const getOpenAtLogin = () => Boolean(config().openAtLogin);
 
+const getAppBundlePath = () => {
+	// /Applications/Webitel.app/Contents/MacOS/Webitel → /Applications/Webitel.app
+	if (process.execPath.includes('.app/Contents/MacOS/')) {
+		return process.execPath.replace(/\/Contents\/MacOS\/[^/]+$/, '');
+	}
+	return process.execPath;
+};
+
+const getLaunchAgentPath = () =>
+	path.join(
+		app.getPath('home'),
+		'Library/LaunchAgents',
+		`${LAUNCH_AGENT_LABEL}.plist`,
+	);
+
+/**
+ * LaunchAgent fallback for macOS. SMAppService (setLoginItemSettings) can report
+ * Enabled but still not launch on some macOS versions; RunAtLoad agent is reliable.
+ */
+const setMacLaunchAgent = (enabled) => {
+	const plistPath = getLaunchAgentPath();
+	const agentsDir = path.dirname(plistPath);
+	const uid = typeof process.getuid === 'function' ? process.getuid() : 501;
+	const domain = `gui/${uid}`;
+
+	if (enabled) {
+		if (!fs.existsSync(agentsDir)) {
+			fs.mkdirSync(agentsDir, {
+				recursive: true,
+			});
+		}
+
+		const appBundle = getAppBundlePath();
+		const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${LAUNCH_AGENT_LABEL}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/bin/open</string>
+		<string>-a</string>
+		<string>${appBundle}</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>LimitLoadToSessionType</key>
+	<string>Aqua</string>
+</dict>
+</plist>
+`;
+		fs.writeFileSync(plistPath, plist);
+
+		try {
+			execFileSync(
+				'launchctl',
+				[
+					'bootout',
+					`${domain}/${LAUNCH_AGENT_LABEL}`,
+				],
+				{
+					stdio: 'ignore',
+				},
+			);
+		} catch {
+			/* not loaded yet */
+		}
+
+		try {
+			execFileSync(
+				'launchctl',
+				[
+					'bootstrap',
+					domain,
+					plistPath,
+				],
+				{
+					stdio: 'ignore',
+				},
+			);
+		} catch (err) {
+			console.error('launchctl bootstrap failed', err);
+			try {
+				execFileSync(
+					'launchctl',
+					[
+						'load',
+						'-w',
+						plistPath,
+					],
+					{
+						stdio: 'ignore',
+					},
+				);
+			} catch (loadErr) {
+				console.error('launchctl load failed', loadErr);
+			}
+		}
+		return;
+	}
+
+	try {
+		execFileSync(
+			'launchctl',
+			[
+				'bootout',
+				`${domain}/${LAUNCH_AGENT_LABEL}`,
+			],
+			{
+				stdio: 'ignore',
+			},
+		);
+	} catch {
+		try {
+			execFileSync(
+				'launchctl',
+				[
+					'unload',
+					'-w',
+					plistPath,
+				],
+				{
+					stdio: 'ignore',
+				},
+			);
+		} catch {
+			/* already unloaded */
+		}
+	}
+
+	if (fs.existsSync(plistPath)) {
+		fs.unlinkSync(plistPath);
+	}
+};
+
+const openLoginItemsSettings = () => {
+	// System Settings → General → Login Items (macOS 13+)
+	shell.openExternal(
+		'x-apple.systempreferences:com.apple.LoginItems-Settings.extension',
+	);
+};
+
+const getOsLoginItemStatus = () => {
+	if (!isSupported()) {
+		return {
+			openAtLogin: false,
+			status: 'not-registered',
+		};
+	}
+	return app.getLoginItemSettings();
+};
+
 const applyLoginItemSettings = (openAtLogin) => {
-	if (!isSupported()) return;
+	if (!isSupported()) return getOsLoginItemStatus();
+
+	const enabled = Boolean(openAtLogin);
 
 	const settings = {
-		openAtLogin: Boolean(openAtLogin),
-		// Always open on screen — never start hidden to tray.
-		openAsHidden: false,
+		openAtLogin: enabled,
 	};
 
 	// path is Windows-only. NSIS/MSI: launch app exe (not Squirrel Update.exe).
@@ -21,7 +179,39 @@ const applyLoginItemSettings = (openAtLogin) => {
 		settings.path = process.execPath;
 	}
 
+	// Do not pass openAsHidden on macOS 13+ (deprecated / ignored; can confuse callers).
 	app.setLoginItemSettings(settings);
+
+	if (isOSX) {
+		setMacLaunchAgent(enabled);
+	}
+
+	const result = getOsLoginItemStatus();
+	console.log('login item settings applied', {
+		requested: enabled,
+		openAtLogin: result.openAtLogin,
+		status: result.status,
+	});
+
+	if (enabled && isOSX && result.status === 'requires-approval') {
+		dialog
+			.showMessageBox({
+				type: 'info',
+				title: 'Open at login',
+				message:
+					'macOS blocked Webitel from opening at login. Enable it in System Settings → General → Login Items.',
+				buttons: [
+					'Open Login Items',
+					'OK',
+				],
+				defaultId: 0,
+			})
+			.then(({ response }) => {
+				if (response === 0) openLoginItemsSettings();
+			});
+	}
+
+	return result;
 };
 
 /** Persist to config.json and sync OS login item. */
@@ -30,7 +220,7 @@ const setOpenAtLogin = (openAtLogin) => {
 	updateConfig({
 		openAtLogin: enabled,
 	});
-	applyLoginItemSettings(enabled);
+	return applyLoginItemSettings(enabled);
 };
 
 /** Apply OS login item from config (source of truth). Default: false. */
@@ -41,7 +231,7 @@ const syncFromConfig = () => {
 			openAtLogin: false,
 		});
 	}
-	applyLoginItemSettings(getOpenAtLogin());
+	return applyLoginItemSettings(getOpenAtLogin());
 };
 
 module.exports = {
@@ -49,4 +239,6 @@ module.exports = {
 	getOpenAtLogin,
 	setOpenAtLogin,
 	syncFromConfig,
+	getOsLoginItemStatus,
+	openLoginItemsSettings,
 };

--- a/packages/electron-workspace/src/main/module/webitel_login_item.js
+++ b/packages/electron-workspace/src/main/module/webitel_login_item.js
@@ -1,177 +1,17 @@
-const { app, dialog, shell } = require('electron');
-const fs = require('fs');
-const path = require('path');
-const { execFileSync } = require('child_process');
-const { isLinux, isWindows, isOSX } = require('../../shared/is');
+const { app } = require('electron');
+const { isLinux, isWindows } = require('../../shared/is');
 const { config, updateConfig } = require('../../shared/config');
-
-const LAUNCH_AGENT_LABEL = 'org.webitel.openAtLogin';
 
 /** macOS + Windows only — Electron has no login-item API on Linux. */
 const isSupported = () => !isLinux;
 
 const getOpenAtLogin = () => Boolean(config().openAtLogin);
 
-const getAppBundlePath = () => {
-	// /Applications/Webitel.app/Contents/MacOS/Webitel → /Applications/Webitel.app
-	if (process.execPath.includes('.app/Contents/MacOS/')) {
-		return process.execPath.replace(/\/Contents\/MacOS\/[^/]+$/, '');
-	}
-	return process.execPath;
-};
-
-const getLaunchAgentPath = () =>
-	path.join(
-		app.getPath('home'),
-		'Library/LaunchAgents',
-		`${LAUNCH_AGENT_LABEL}.plist`,
-	);
-
-/**
- * LaunchAgent fallback for macOS. SMAppService (setLoginItemSettings) can report
- * Enabled but still not launch on some macOS versions; RunAtLoad agent is reliable.
- */
-const setMacLaunchAgent = (enabled) => {
-	const plistPath = getLaunchAgentPath();
-	const agentsDir = path.dirname(plistPath);
-	const uid = typeof process.getuid === 'function' ? process.getuid() : 501;
-	const domain = `gui/${uid}`;
-
-	if (enabled) {
-		if (!fs.existsSync(agentsDir)) {
-			fs.mkdirSync(agentsDir, {
-				recursive: true,
-			});
-		}
-
-		const appBundle = getAppBundlePath();
-		const plist = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>Label</key>
-	<string>${LAUNCH_AGENT_LABEL}</string>
-	<key>ProgramArguments</key>
-	<array>
-		<string>/usr/bin/open</string>
-		<string>-a</string>
-		<string>${appBundle}</string>
-	</array>
-	<key>RunAtLoad</key>
-	<true/>
-	<key>LimitLoadToSessionType</key>
-	<string>Aqua</string>
-</dict>
-</plist>
-`;
-		fs.writeFileSync(plistPath, plist);
-
-		try {
-			execFileSync(
-				'launchctl',
-				[
-					'bootout',
-					`${domain}/${LAUNCH_AGENT_LABEL}`,
-				],
-				{
-					stdio: 'ignore',
-				},
-			);
-		} catch {
-			/* not loaded yet */
-		}
-
-		try {
-			execFileSync(
-				'launchctl',
-				[
-					'bootstrap',
-					domain,
-					plistPath,
-				],
-				{
-					stdio: 'ignore',
-				},
-			);
-		} catch (err) {
-			console.error('launchctl bootstrap failed', err);
-			try {
-				execFileSync(
-					'launchctl',
-					[
-						'load',
-						'-w',
-						plistPath,
-					],
-					{
-						stdio: 'ignore',
-					},
-				);
-			} catch (loadErr) {
-				console.error('launchctl load failed', loadErr);
-			}
-		}
-		return;
-	}
-
-	try {
-		execFileSync(
-			'launchctl',
-			[
-				'bootout',
-				`${domain}/${LAUNCH_AGENT_LABEL}`,
-			],
-			{
-				stdio: 'ignore',
-			},
-		);
-	} catch {
-		try {
-			execFileSync(
-				'launchctl',
-				[
-					'unload',
-					'-w',
-					plistPath,
-				],
-				{
-					stdio: 'ignore',
-				},
-			);
-		} catch {
-			/* already unloaded */
-		}
-	}
-
-	if (fs.existsSync(plistPath)) {
-		fs.unlinkSync(plistPath);
-	}
-};
-
-const openLoginItemsSettings = () => {
-	// System Settings → General → Login Items (macOS 13+)
-	shell.openExternal(
-		'x-apple.systempreferences:com.apple.LoginItems-Settings.extension',
-	);
-};
-
-const getOsLoginItemStatus = () => {
-	if (!isSupported()) {
-		return {
-			openAtLogin: false,
-			status: 'not-registered',
-		};
-	}
-	return app.getLoginItemSettings();
-};
-
 const applyLoginItemSettings = (openAtLogin) => {
-	if (!isSupported()) return getOsLoginItemStatus();
-
-	const enabled = Boolean(openAtLogin);
+	if (!isSupported()) return;
 
 	const settings = {
-		openAtLogin: enabled,
+		openAtLogin: Boolean(openAtLogin),
 	};
 
 	// path is Windows-only. NSIS/MSI: launch app exe (not Squirrel Update.exe).
@@ -179,39 +19,7 @@ const applyLoginItemSettings = (openAtLogin) => {
 		settings.path = process.execPath;
 	}
 
-	// Do not pass openAsHidden on macOS 13+ (deprecated / ignored; can confuse callers).
 	app.setLoginItemSettings(settings);
-
-	if (isOSX) {
-		setMacLaunchAgent(enabled);
-	}
-
-	const result = getOsLoginItemStatus();
-	console.log('login item settings applied', {
-		requested: enabled,
-		openAtLogin: result.openAtLogin,
-		status: result.status,
-	});
-
-	if (enabled && isOSX && result.status === 'requires-approval') {
-		dialog
-			.showMessageBox({
-				type: 'info',
-				title: 'Open at login',
-				message:
-					'macOS blocked Webitel from opening at login. Enable it in System Settings → General → Login Items.',
-				buttons: [
-					'Open Login Items',
-					'OK',
-				],
-				defaultId: 0,
-			})
-			.then(({ response }) => {
-				if (response === 0) openLoginItemsSettings();
-			});
-	}
-
-	return result;
 };
 
 /** Persist to config.json and sync OS login item. */
@@ -220,7 +28,7 @@ const setOpenAtLogin = (openAtLogin) => {
 	updateConfig({
 		openAtLogin: enabled,
 	});
-	return applyLoginItemSettings(enabled);
+	applyLoginItemSettings(enabled);
 };
 
 /** Apply OS login item from config (source of truth). Default: false. */
@@ -231,7 +39,7 @@ const syncFromConfig = () => {
 			openAtLogin: false,
 		});
 	}
-	return applyLoginItemSettings(getOpenAtLogin());
+	applyLoginItemSettings(getOpenAtLogin());
 };
 
 module.exports = {
@@ -239,6 +47,4 @@ module.exports = {
 	getOpenAtLogin,
 	setOpenAtLogin,
 	syncFromConfig,
-	getOsLoginItemStatus,
-	openLoginItemsSettings,
 };

--- a/packages/electron-workspace/src/main/windows.js
+++ b/packages/electron-workspace/src/main/windows.js
@@ -205,10 +205,13 @@ class WebitelWindows {
 	}
 
 	restoreWindow() {
+		const target = this.workspace.window || this.loadConfig?.window;
+		if (!target) return;
+
+		if (target.isMinimized()) target.restore();
+		if (!target.isVisible()) target.show();
+		target.focus();
 		if (this.workspace.window) {
-			if (this.workspace.window.isMinimized()) this.workspace.window.restore();
-			this.workspace.window.isVisible() ? null : this.workspace.window.show();
-			this.workspace.window.focus();
 			this.workspace.window.center();
 		}
 	}


### PR DESCRIPTION
## Summary
- macOS: SMAppService (`setLoginItemSettings`) can report Enabled but still not launch — add `~/Library/LaunchAgents/org.webitel.openAtLogin.plist` fallback (`open -a` at login)
- Surface `requires-approval` with dialog + deep-link to System Settings → Login Items
- Force-show workspace window on `ready` / `activate` (hide-to-tray + TAL restore left window hidden)

## Test plan
- [ ] Rebuild/install macOS app from this branch
- [ ] Enable Open at login in tray
- [ ] Confirm plist exists: `~/Library/LaunchAgents/org.webitel.openAtLogin.plist`
- [ ] System Settings → General → Login Items / Allow in the Background — enable Webitel if prompted
- [ ] Log out/in — Webitel opens with window on screen
- [ ] Disable tray toggle — plist removed, no autostart
- [ ] Windows still works as before

https://webitel.atlassian.net/browse/DEV-6800


Made with [Cursor](https://cursor.com)