### PR TITLE
fix(electron): guard destroyed BrowserWindow refs in main process [WTEL-10064]

### DIFF
--- a/packages/electron-workspace/src/main/index.js
+++ b/packages/electron-workspace/src/main/index.js
@@ -9,6 +9,7 @@ const { autoUpdater } = require('electron-updater');
 const conf = require('../shared/config').config();
 const WebitelWindows = require('./windows');
 const WebitelTray = require('./module/webitel_tray');
+const { isAlive } = require('./module/window_utils');
 
 const win = new WebitelWindows();
 let tray = {};
@@ -136,7 +137,7 @@ app.on('ready', () => {
 });
 
 app.on('activate', () => {
-	if (win.workspace?.window || win.loadConfig?.window) {
+	if (isAlive(win.workspace?.window) || isAlive(win.loadConfig?.window)) {
 		win.restoreWindow();
 		return;
 	}

--- a/packages/electron-workspace/src/main/module/webitel_workspace.js
+++ b/packages/electron-workspace/src/main/module/webitel_workspace.js
@@ -1,11 +1,15 @@
 const { app, BrowserWindow, shell } = require('electron');
 const path = require('path');
+const { isAlive } = require('./window_utils');
 
 class Workspace {
 	window = null;
 
 	createWindow(URL) {
-		if (this.window) return;
+		if (isAlive(this.window)) return;
+		// the ref can hold a destroyed window whose 'closed' event never fired
+		// (app.exit / OS teardown) — drop it so recreation proceeds
+		this.window = null;
 		this.window = new BrowserWindow({
 			minWidth: 900,
 			minHeight: 600,
@@ -40,6 +44,8 @@ class Workspace {
 		});
 
 		this.window.loadURL(URL).catch((err) => {
+			// window may be destroyed/replaced while the URL was loading
+			if (!isAlive(this.window)) return;
 			const devUrl = process.env.ELECTRON_RENDERER_URL;
 			if (devUrl) {
 				this.window.loadURL(`${devUrl}/windows/err-message/index.html`);
@@ -52,6 +58,7 @@ class Workspace {
 
 		this.window.on('close', (event) => {
 			// close if windows sleep
+			if (!isAlive(this.window)) return;
 			if (!this.window.doDestroy) {
 				this.window.hide();
 				event.preventDefault();
@@ -64,7 +71,7 @@ class Workspace {
 	}
 
 	changeSIP(value) {
-		if (this.window) {
+		if (isAlive(this.window)) {
 			const str = `{'ON_SITE':true,'CLI':{'debug':false,'registerWebDevice':${value}}}`;
 			this.window.webContents.executeJavaScript(
 				`localStorage.setItem("CONFIG", "${str}");`,
@@ -74,7 +81,7 @@ class Workspace {
 	}
 
 	changeLang(lang) {
-		if (this.window) {
+		if (isAlive(this.window)) {
 			this.window.webContents.executeJavaScript(
 				`localStorage.setItem("lang", "${lang}");`,
 				true,
@@ -84,6 +91,7 @@ class Workspace {
 	}
 
 	updateWindow(ob) {
+		if (!isAlive(this.window)) return;
 		this.window
 			.loadURL(ob.URL)
 			.then(() => {
@@ -98,10 +106,12 @@ class Workspace {
 	}
 
 	sandCallAction(call) {
+		if (!isAlive(this.window)) return;
 		this.window.webContents.send('call-action', call);
 	}
 
 	reload() {
+		if (!isAlive(this.window)) return;
 		this.window.webContents.reloadIgnoringCache();
 	}
 }

--- a/packages/electron-workspace/src/main/module/webitel_workspace.js
+++ b/packages/electron-workspace/src/main/module/webitel_workspace.js
@@ -102,7 +102,10 @@ class Workspace {
 				});
 				app.exit(0);
 			})
-			.catch((err) => this.window.send('from-main', err));
+			.catch((err) => {
+				if (!isAlive(this.window)) return;
+				this.window.webContents.send('from-main', err);
+			});
 	}
 
 	sandCallAction(call) {

--- a/packages/electron-workspace/src/main/module/window_utils.js
+++ b/packages/electron-workspace/src/main/module/window_utils.js
@@ -1,0 +1,8 @@
+// A destroyed BrowserWindow is still truthy, and callNotification inits
+// `window = {}` (no isDestroyed method) — plain truthy checks are not enough.
+const isAlive = (win) =>
+	Boolean(win && typeof win.isDestroyed === 'function' && !win.isDestroyed());
+
+module.exports = {
+	isAlive,
+};

--- a/packages/electron-workspace/src/main/windows.js
+++ b/packages/electron-workspace/src/main/windows.js
@@ -6,7 +6,8 @@ const { app, BrowserWindow, dialog, shell } = require('electron'),
 	conf = require('../shared/config').config(),
 	LoadConfig = require('./module/webitel_load_config'),
 	CallNotification = require('./module/webitel_call_notification'),
-	DisconnectNotification = require('./module/webitel_disconnect_notification');
+	DisconnectNotification = require('./module/webitel_disconnect_notification'),
+	{ isAlive } = require('./module/window_utils');
 
 class WebitelWindows {
 	lStorage = new LStorage();
@@ -16,6 +17,7 @@ class WebitelWindows {
 	workspace = new Workspace();
 	disconnectNotification = new DisconnectNotification();
 	openUrlOnAnswer = conf.openUrlOnAnswer;
+	_resumeTimer = null;
 
 	start(URL = conf.URL, useSIP = conf.useSIP) {
 		if (URL) {
@@ -28,14 +30,16 @@ class WebitelWindows {
 	}
 
 	sleep() {
-		if (this.workspace.window) {
-			this.workspace.window.doDestroy = true;
-			this.workspace.window.close();
-		}
+		// already gone == already asleep
+		if (!isAlive(this.workspace.window)) return;
+		this.workspace.window.doDestroy = true;
+		this.workspace.window.close();
 	}
 
 	resume() {
-		setTimeout(() => {
+		// macOS fires both 'resume' and 'unlock-screen' on wake — keep one timer
+		clearTimeout(this._resumeTimer);
+		this._resumeTimer = setTimeout(() => {
 			this.workspace.createWindow(conf.URL, conf.useSIP);
 		}, 5000);
 	}
@@ -56,6 +60,7 @@ class WebitelWindows {
 	}
 
 	onChangeSIP(value) {
+		if (!isAlive(this.workspace.window)) return;
 		this.workspace.window.webContents.send('change-SIP', {
 			isSIP: value,
 			timeoutSIP: conf.timeoutSIP,
@@ -70,15 +75,16 @@ class WebitelWindows {
 	}
 
 	sendMessage(event, message) {
-		if (this.loadConfig?.window)
-			this.loadConfig?.window.webContents.send(event, message);
+		if (isAlive(this.loadConfig?.window))
+			this.loadConfig.window.webContents.send(event, message);
 
-		if (this.workspace?.window)
+		if (isAlive(this.workspace?.window))
 			this.workspace.window.webContents.send(event, message);
 	}
 
 	openDevTools() {
 		const w = BrowserWindow.getFocusedWindow();
+		if (!w) return;
 		w.webContents.isDevToolsOpened()
 			? w.webContents.closeDevTools()
 			: w.webContents.openDevTools();
@@ -151,7 +157,7 @@ class WebitelWindows {
 	}
 
 	restartWorkspace(ob) {
-		if (this.workspace.window) {
+		if (isAlive(this.workspace.window)) {
 			this.workspace.window
 				.loadURL(ob.URL)
 				.then(() => {
@@ -172,7 +178,7 @@ class WebitelWindows {
 				this.loadConfig.hide();
 				this.config.writeConfig();
 				this.start(ob.URL);
-			} else {
+			} else if (isAlive(this.loadConfig.window)) {
 				this.loadConfig.window.send('from-main', 'URL Is Not Valid');
 			}
 		}
@@ -190,13 +196,14 @@ class WebitelWindows {
 	}
 
 	setWorkspaceVisible() {
-		if (this.workspace.window)
+		if (isAlive(this.workspace.window))
 			this.workspace.window.isVisible()
 				? this.workspace.window.hide()
 				: this.workspace.window.show();
 	}
 
 	changeUserStatus(status) {
+		if (!isAlive(this.workspace.window)) return;
 		this.workspace.window.webContents.send('change-status', status);
 	}
 
@@ -205,19 +212,25 @@ class WebitelWindows {
 	}
 
 	restoreWindow() {
-		const target = this.workspace.window || this.loadConfig?.window;
+		const workspaceWin = isAlive(this.workspace.window)
+			? this.workspace.window
+			: null;
+		const target =
+			workspaceWin ||
+			(isAlive(this.loadConfig?.window) ? this.loadConfig.window : null);
 		if (!target) return;
 
 		if (target.isMinimized()) target.restore();
 		if (!target.isVisible()) target.show();
 		target.focus();
-		if (this.workspace.window) {
-			this.workspace.window.center();
+		if (workspaceWin) {
+			workspaceWin.center();
 		}
 	}
 
 	makeCall(destination = null) {
 		if (!destination) return;
+		if (!isAlive(this.workspace.window)) return;
 		this.workspace.window.webContents.send('make-call', destination);
 	}
 
@@ -234,11 +247,13 @@ class WebitelWindows {
 	}
 
 	showDisconnectNotification() {
+		if (!isAlive(this.disconnectNotification.window)) return;
 		this.disconnectNotification.setBounds();
 		this.disconnectNotification.window.show(); // https://webitel.atlassian.net/browse/WTEL-9965
 	}
 
 	hideDisconnectNotification() {
+		if (!isAlive(this.disconnectNotification.window)) return;
 		this.disconnectNotification.window.hide();
 	}
 }

--- a/packages/electron-workspace/src/main/windows.js
+++ b/packages/electron-workspace/src/main/windows.js
@@ -172,14 +172,20 @@ class WebitelWindows {
 					});
 					app.exit(0);
 				})
-				.catch((err) => this.workspace.window.send('from-main', err));
+				.catch((err) => {
+					if (!isAlive(this.workspace.window)) return;
+					this.workspace.window.webContents.send('from-main', err);
+				});
 		} else {
 			if (this._isValidHttpUrl(ob.URL)) {
 				this.loadConfig.hide();
 				this.config.writeConfig();
 				this.start(ob.URL);
 			} else if (isAlive(this.loadConfig.window)) {
-				this.loadConfig.window.send('from-main', 'URL Is Not Valid');
+				this.loadConfig.window.webContents.send(
+					'from-main',
+					'URL Is Not Valid',
+				);
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

[WTEL-10064](https://webitel.atlassian.net/browse/WTEL-10064) — QA (macOS, build 1.4.2): after a laptop reboot, every screen lock/suspend shows

> Uncaught Exception: TypeError: Object has been destroyed at WebitelWindows.sleep (out/main/index.js:493)

and the app can no longer be opened.

## Root cause

`Workspace.window` is nulled **only** in the `closed` event handler. When the window is torn down without that event being delivered (`app.exit(0)` paths, OS teardown at reboot, macOS relaunch), the ref keeps a destroyed-but-truthy `BrowserWindow`:

- `sleep()` guarded only with truthiness → `close()` on a destroyed window throws inside the powerMonitor handler → uncaught exception dialog on every lock/suspend (app stays resident via tray + notification windows).
- `createWindow` early-returned on the truthy stale ref → `resume()` / `activate` could never recreate the window → app permanently window-less.

There were zero `isDestroyed()` checks in `src/main`; many sibling methods (tray/IPC paths) had the same crash class.

## Fix

- New `src/main/module/window_utils.js` with `isAlive(win)` (truthy + has `isDestroyed` + not destroyed; `typeof` check needed because callNotification inits `window = {}`).
- `sleep()` no-ops on a dead window; all window-touching methods in `windows.js` / `webitel_workspace.js` guarded (`onChangeSIP`, `sendMessage`, `openDevTools`, `restartWorkspace`, `setWorkspaceVisible`, `changeUserStatus`, `restoreWindow`, `makeCall`, `show/hideDisconnectNotification`, `changeSIP`, `changeLang`, `updateWindow`, `sandCallAction`, `reload`, `loadURL().catch()`).
- `createWindow` drops a stale destroyed ref and recreates the window — recovery path for `resume()`, `activate`, and `start()`.
- `resume()` debounced: macOS fires both `resume` and `unlock-screen` on wake.
- `app.on('activate')` uses `isAlive`, so a dock-icon click also recovers from the stale state.
- Bonus fix: `updateWindow`/`restartWorkspace` error handlers and the invalid-URL branch called `BrowserWindow.send(...)`, which doesn't exist — the renderer never received the `from-main` error. Now `webContents.send` with liveness guards.

## Verification

- Scratch Electron script reproduced the exact production state (destroyed window with `closed` listener removed so the ref is never nulled): 15/15 checks pass — `sleep()` and all tray/IPC paths no longer throw, window is recreated after a stale ref, no duplicate window while alive, resume debounce keeps one timer, X-button close still hides instead of destroying.
- `npm run build` passes; lint/typecheck diagnostics identical to `main` (pre-existing only).
- Left for QA on real hardware: lock/unlock, `pmset sleepnow`, and the reboot scenario from the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WTEL-10064]: https://webitel.atlassian.net/browse/WTEL-10064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ