### PR TITLE
feat(workspace): auto-detect softphone companion instead of config flag [WTEL-10073]

### DIFF
--- a/packages/electron-softphone-companion/README.md
+++ b/packages/electron-softphone-companion/README.md
@@ -32,25 +32,37 @@ only the operations that require a local SIP device go through this utility.
   Tokens are kept in memory only.
 - Audio is routed natively by pjsip to the OS default input/output devices.
 
-## Enabling in the web workspace
+## Detection in the web workspace
 
-In the workspace's `config.json` (or any layer of its config merge):
+**Auto by default**: at every client creation (login, reload, reconnect) the
+workspace probes `ws://127.0.0.1:<port>`. A running utility answers within
+milliseconds → the browser switches to external mode (skips the microphone
+probe, never registers the web SIP device, reuses the probe socket). No
+utility → instant connection-refused → the usual web phone. Start the utility
+and reload the page to switch modes.
+
+`CONFIG.CLI.externalSoftphone` (workspace `config.json` or any layer of its
+config merge) refines this:
 
 ```json
 {
 	"CLI": {
 		"externalSoftphone": {
-			"enabled": true,
-			"port": 10029
+			"port": 10029,
+			"enabled": true
 		}
 	}
 }
 ```
 
-With the flag on, the browser skips the microphone probe, never registers the
-web SIP device, and probes `ws://127.0.0.1:<port>` with backoff until the
-utility appears. The answer button lights up only while the utility reports
-`sipRegistered: true` (existing `isPhoneReg` flow).
+- `enabled` absent → **auto** (probe, default)
+- `enabled: true` → **forced**: always external, never a web device; the
+  manager keeps probing for the utility with backoff
+- `enabled: false` → **disabled**: never probe, always the web phone
+
+In every external mode the answer button lights up only while the utility
+reports `sipRegistered: true` (existing `isPhoneReg` flow). In Safari the
+probe is blocked (mixed content) and auto mode falls back to the web phone.
 
 ## Admin prerequisites
 

--- a/public/config.json
+++ b/public/config.json
@@ -4,7 +4,6 @@
 		"debug": false,
 		"registerWebDevice": true,
 		"externalSoftphone": {
-			"enabled": false,
 			"port": 10029
 		}
 	},

--- a/src/app/api/agent-workspace/external-softphone/config.ts
+++ b/src/app/api/agent-workspace/external-softphone/config.ts
@@ -1,24 +1,33 @@
+/**
+ * How the external-softphone mode is chosen for a client generation:
+ * - 'auto' (default, `enabled` absent): probe ws://127.0.0.1:<port> at client
+ *   creation — a running utility (packages/electron-softphone-companion)
+ *   switches the browser to control-only mode, otherwise the web phone is
+ *   used as usual;
+ * - 'forced' (`enabled: true`): always external, never register a web device
+ *   (the manager keeps probing for the utility with backoff);
+ * - 'disabled' (`enabled: false`): never probe, always the web phone.
+ *
+ * Configured via CONFIG.CLI.externalSoftphone (public/config.json or the
+ * per-user phone settings merge in main.ts).
+ */
+export type ExternalSoftphoneMode = 'auto' | 'forced' | 'disabled';
+
 export interface ExternalSoftphoneConfig {
-	enabled: boolean;
+	mode: ExternalSoftphoneMode;
 	port: number;
 }
 
 export const EXTERNAL_SOFTPHONE_DEFAULT_PORT = 10029;
 
-/**
- * External softphone mode: the browser is control-only and a local Electron
- * utility (packages/electron-softphone-companion) is the actual SIP endpoint.
- * Configured via CONFIG.CLI.externalSoftphone (public/config.json or the
- * per-user phone settings merge in main.ts).
- */
 export function getExternalSoftphoneConfig(): ExternalSoftphoneConfig {
-	const disabled = {
-		enabled: false,
+	const fallback: ExternalSoftphoneConfig = {
+		mode: 'auto',
 		port: EXTERNAL_SOFTPHONE_DEFAULT_PORT,
 	};
 	try {
 		const configStr = localStorage.getItem('CONFIG');
-		if (!configStr) return disabled;
+		if (!configStr) return fallback;
 		const parsedConfig = JSON.parse(configStr) as {
 			CLI?: {
 				externalSoftphone?: {
@@ -28,16 +37,17 @@ export function getExternalSoftphoneConfig(): ExternalSoftphoneConfig {
 			};
 		};
 		const externalSoftphone = parsedConfig.CLI?.externalSoftphone;
-		if (!externalSoftphone?.enabled) return disabled;
+		const mode: ExternalSoftphoneMode =
+			externalSoftphone?.enabled === true
+				? 'forced'
+				: externalSoftphone?.enabled === false
+					? 'disabled'
+					: 'auto';
 		return {
-			enabled: true,
-			port: Number(externalSoftphone.port) || EXTERNAL_SOFTPHONE_DEFAULT_PORT,
+			mode,
+			port: Number(externalSoftphone?.port) || EXTERNAL_SOFTPHONE_DEFAULT_PORT,
 		};
 	} catch {
-		return disabled;
+		return fallback;
 	}
-}
-
-export function isExternalSoftphoneEnabled(): boolean {
-	return getExternalSoftphoneConfig().enabled;
 }

--- a/src/app/api/agent-workspace/external-softphone/useExternalSoftphone.ts
+++ b/src/app/api/agent-workspace/external-softphone/useExternalSoftphone.ts
@@ -7,6 +7,9 @@ import { RemotePhone } from './RemotePhone';
 const PROTOCOL_VERSION = 1;
 const RECONNECT_BASE_DELAY = 1000;
 const MAX_RECONNECT_DELAY = 15000;
+// connection refused on loopback settles in milliseconds; the timeout only
+// guards pathological cases (filtered port, Safari blocking the attempt)
+const PROBE_TIMEOUT = 1500;
 
 interface SoftphoneState {
 	state?: string;
@@ -24,12 +27,25 @@ interface SoftphoneState {
 
 let ws: WebSocket | null = null;
 let started = false;
+let active = false;
 let seq = 0;
 let reconnectAttempts = 0;
 let reconnectTimerId: number | null = null;
 let currentCli: Client | null = null;
 let currentPhone: RemotePhone | null = null;
 let lastState: SoftphoneState | null = null;
+// socket opened by probe(), adopted by the next start() so the utility does
+// not see a connect/disconnect flap between detection and use
+let pendingSocket: WebSocket | null = null;
+
+/**
+ * Whether the current client generation runs in external-softphone mode.
+ * Runtime state, not config: in auto mode only a successful probe makes it
+ * true. Used by call-store gates (mic bypass, audio-only).
+ */
+export function isExternalPhoneActive(): boolean {
+	return active;
+}
 
 function send(type: string, payload: Record<string, unknown> = {}) {
 	if (!ws || ws.readyState !== WebSocket.OPEN) return;
@@ -68,6 +84,9 @@ function attach() {
 	const cli = currentCli;
 	if (!cli || !ws || ws.readyState !== WebSocket.OPEN) return;
 	if (currentPhone && cli.phone === currentPhone) return;
+	// never displace a foreign phone (e.g. the webrtc SipPhone of a client
+	// generation that was created without external mode)
+	if (cli.phone && !(cli.phone instanceof RemotePhone)) return;
 
 	// a fresh RemotePhone per attach: subscribePhone() adds listeners on the
 	// phone, so reusing one instance across client generations would keep
@@ -150,27 +169,33 @@ function handleMessage(raw: string) {
 	}
 }
 
+function wireSocket(socket: WebSocket) {
+	ws = socket;
+	socket.onmessage = (event) => handleMessage(event.data);
+	socket.onclose = () => {
+		ws = null;
+		detach();
+		scheduleReconnect();
+	};
+	socket.onerror = () => {
+		// onclose follows and drives the retry
+	};
+}
+
 function connect() {
 	const { port } = getExternalSoftphoneConfig();
+	let socket: WebSocket;
 	try {
-		ws = new WebSocket(`ws://127.0.0.1:${port}`);
+		socket = new WebSocket(`ws://127.0.0.1:${port}`);
 	} catch {
 		scheduleReconnect();
 		return;
 	}
 
-	ws.onopen = () => {
+	wireSocket(socket);
+	socket.onopen = () => {
 		reconnectAttempts = 0;
 		sendHello();
-	};
-	ws.onmessage = (event) => handleMessage(event.data);
-	ws.onclose = () => {
-		ws = null;
-		detach();
-		scheduleReconnect();
-	};
-	ws.onerror = () => {
-		// onclose follows and drives the retry
 	};
 }
 
@@ -194,15 +219,75 @@ function scheduleReconnect() {
 
 export function useExternalSoftphone() {
 	/**
+	 * Detect a running utility: open a socket to the loopback port and keep it
+	 * for the next start() on success. Resolves false on refusal, timeout, or
+	 * a blocked attempt (e.g. Safari mixed content) — the caller then falls
+	 * back to the web phone.
+	 */
+	function probe(): Promise<boolean> {
+		if (pendingSocket && pendingSocket.readyState === WebSocket.OPEN) {
+			return Promise.resolve(true);
+		}
+		if (ws && ws.readyState === WebSocket.OPEN) {
+			// manager already connected (reconnect of the web client)
+			return Promise.resolve(true);
+		}
+		const { port } = getExternalSoftphoneConfig();
+		return new Promise((resolve) => {
+			let settled = false;
+			let socket: WebSocket;
+			const settle = (ok: boolean) => {
+				if (settled) return;
+				settled = true;
+				window.clearTimeout(timer);
+				resolve(ok);
+			};
+			const timer = window.setTimeout(() => {
+				try {
+					socket.close();
+				} catch {
+					// closing a CONNECTING socket may throw in some browsers
+				}
+				settle(false);
+			}, PROBE_TIMEOUT);
+			try {
+				socket = new WebSocket(`ws://127.0.0.1:${port}`);
+			} catch {
+				settle(false);
+				return;
+			}
+			socket.onerror = () => settle(false);
+			socket.onclose = () => {
+				if (pendingSocket === socket) pendingSocket = null;
+				settle(false);
+			};
+			socket.onopen = () => {
+				pendingSocket = socket;
+				settle(true);
+			};
+		});
+	}
+
+	/**
 	 * Call after every successful cli.auth() (each client generation): stores
 	 * the live client, re-hands the (possibly refreshed) token to the utility
 	 * and re-attaches the phone.
 	 */
 	function start(cli: Client) {
 		currentCli = cli;
+		active = true;
 		if (!started) {
 			started = true;
-			connect();
+			if (pendingSocket && pendingSocket.readyState === WebSocket.OPEN) {
+				// adopt the probe socket instead of reconnecting
+				const socket = pendingSocket;
+				pendingSocket = null;
+				wireSocket(socket);
+				sendHello();
+			} else {
+				pendingSocket = null;
+				connect();
+			}
 			return;
 		}
 		if (ws && ws.readyState === WebSocket.OPEN) {
@@ -229,9 +314,15 @@ export function useExternalSoftphone() {
 	function stop() {
 		detach();
 		currentCli = null;
+		active = false;
 		if (reconnectTimerId) {
 			window.clearTimeout(reconnectTimerId);
 			reconnectTimerId = null;
+		}
+		if (pendingSocket) {
+			pendingSocket.onclose = null;
+			pendingSocket.close();
+			pendingSocket = null;
 		}
 		if (ws) {
 			ws.onclose = null;
@@ -242,6 +333,7 @@ export function useExternalSoftphone() {
 	}
 
 	return {
+		probe,
 		start,
 		stop,
 		clearClient,

--- a/src/app/api/agent-workspace/websocket/useWebSocketClient.ts
+++ b/src/app/api/agent-workspace/websocket/useWebSocketClient.ts
@@ -188,9 +188,21 @@ async function createClient(): Promise<Client> {
 	const token = localStorage.getItem('access-token');
 	const cliConfig = getCliConfig();
 	// external softphone mode: the local utility is the SIP endpoint, the
-	// browser is control-only — no web device, no microphone needed
+	// browser is control-only — no web device, no microphone needed. In auto
+	// mode the decision is a loopback probe for a running utility, re-taken on
+	// every client generation (reload/reconnect picks up a started/quit
+	// utility).
 	const externalSoftphone = getExternalSoftphoneConfig();
-	const browserPermissions = externalSoftphone.enabled
+	const softphoneManager = useExternalSoftphone();
+	const useExternalPhone =
+		externalSoftphone.mode === 'forced' ||
+		(externalSoftphone.mode === 'auto' && (await softphoneManager.probe()));
+	if (!useExternalPhone) {
+		// kill a manager left over from a previous external-mode generation so
+		// it can't attach a RemotePhone onto this web-phone client later
+		softphoneManager.stop();
+	}
+	const browserPermissions = useExternalPhone
 		? {
 				micGranted: false,
 			}
@@ -203,7 +215,7 @@ async function createClient(): Promise<Client> {
 			endpoint,
 			token,
 			registerWebDevice:
-				!externalSoftphone.enabled &&
+				!useExternalPhone &&
 				(cliConfig.registerWebDevice ?? true) &&
 				(browserPermissions.micGranted ?? false),
 			debug: cliConfig.debug,
@@ -225,10 +237,10 @@ async function createClient(): Promise<Client> {
 	await cli.auth();
 
 	emit(WebSocketClientEvent.AfterAuth, cli);
-	if (externalSoftphone.enabled) {
+	if (useExternalPhone) {
 		// attaches the RemotePhone and hands the token to the local utility;
 		// no phone.ua will ever exist, so markAsyncPhoneRaw is skipped
-		useExternalSoftphone().start(cli);
+		softphoneManager.start(cli);
 	} else {
 		await markAsyncPhoneRaw(cli);
 	}

--- a/src/features/modules/call/call.js
+++ b/src/features/modules/call/call.js
@@ -2,7 +2,7 @@ import { QueueTypeName } from '@webitel/ui-sdk/enums';
 import eventBus from '@webitel/ui-sdk/scripts/eventBus.js';
 import { DeviceNotAllowPermissionError } from 'webitel-sdk';
 
-import { isExternalSoftphoneEnabled } from '../../../app/api/agent-workspace/external-softphone/config';
+import { isExternalPhoneActive } from '../../../app/api/agent-workspace/external-softphone/useExternalSoftphone';
 import i18n from '../../../app/locale/i18n.js';
 import WorkspaceStates from '../../../ui/enums/WorkspaceState.enum';
 import clientHandlers from './client-handlers';
@@ -101,7 +101,7 @@ const actions = {
 		const params = {
 			...CALL_PARAMS,
 			// the external softphone (pjsip) is audio-only
-			video: context.state.isVideo && !isExternalSoftphoneEnabled(),
+			video: context.state.isVideo && !isExternalPhoneActive(),
 		};
 		await client.call({
 			destination,
@@ -121,7 +121,7 @@ const actions = {
 		// in external softphone mode audio is captured by the local utility,
 		// not the browser — no local mic (or camera/video) involved
 		const isMicAllowed =
-			isExternalSoftphoneEnabled() || (await isMicrophoneAllowed());
+			isExternalPhoneActive() || (await isMicrophoneAllowed());
 		if (!isMicAllowed) {
 			eventBus.$emit('notification', {
 				type: 'error',
@@ -133,7 +133,7 @@ const actions = {
 		}
 
 		const isVideoCall =
-			!isExternalSoftphoneEnabled() &&
+			!isExternalPhoneActive() &&
 			context.rootGetters['features/call/videoCall/IS_VIDEO_CALL'](call);
 
 		if (isVideoCall) {


### PR DESCRIPTION
## Summary

The external-softphone mode is now chosen by **probing** `ws://127.0.0.1:<port>` at every client creation instead of requiring a config flag:

- utility running → answers in milliseconds → browser goes control-only (no mic probe, no web SIP device); the probe socket is adopted by the connection manager, so the utility sees no connect/disconnect flap
- no utility → instant connection-refused → the usual web phone
- re-evaluated per client generation: reload/reconnect picks up a started or quit utility
- Safari (mixed-content-blocked probe) gracefully falls back to the web phone

`CLI.externalSoftphone.enabled` becomes a tri-state override: **absent = auto** (new default in `public/config.json`), `true` = forced external, `false` = never probe.

Implementation notes:
- call-store gates (mic bypass, audio-only) read the runtime mode via `isExternalPhoneActive()` — in auto mode config alone can't answer
- `attach()` refuses to displace a foreign (webrtc) phone across client generations; the manager is stopped when a generation picks the web phone

Jira: [WTEL-10073](https://webitel.atlassian.net/browse/WTEL-10073)

## Test plan

- [ ] utility running + reload → external mode, no mic prompt, answer via native SIP
- [ ] utility not running + reload → webrtc mode with mic prompt (probe adds no noticeable delay)
- [ ] quit utility mid-session → UI degrades; after reload → webrtc mode
- [ ] `enabled: false` in config → never probes; `enabled: true` → external even before utility starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WTEL-10073]: https://webitel.atlassian.net/browse/WTEL-10073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ